### PR TITLE
Update goji to 0.7.6

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*", "packages/goji.js.org/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.7.4"
+  "version": "0.7.6"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/cli",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "GojiJS CLI",
   "main": "dist/cjs/index.js",
   "bin": {
@@ -40,7 +40,7 @@
     "@babel/preset-react": "^7.10.1",
     "@babel/preset-typescript": "^7.10.1",
     "@babel/runtime": "^7.10.1",
-    "@goji/webpack-plugin": "^0.7.4",
+    "@goji/webpack-plugin": "^0.7.6",
     "babel-loader": "^8.1.0",
     "cache-loader": "^4.1.0",
     "chalk": "^4.0.0",
@@ -65,7 +65,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@goji/core": "^0.7.4",
+    "@goji/core": "^0.7.6",
     "@types/yargs": "^15.0.5"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/core",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "GojiJS Core",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/testing-library",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "GojiJS Testing Library",
   "main": "dist/cjs/index.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "react": "*"
   },
   "devDependencies": {
-    "@goji/core": "^0.7.4",
+    "@goji/core": "^0.7.6",
     "@types/lodash": "^4.14.151",
     "@types/react-test-renderer": "^16.9.2",
     "react": "^16.13.1"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/webpack-plugin",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "GojiJS Webpack Plugin",
   "main": "dist/cjs/cjs.js",
   "module": "dist/esm/index.js",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
-    "@goji/core": "^0.7.4",
+    "@goji/core": "^0.7.6",
     "@types/ejs": "^3.0.4",
     "@types/enhanced-resolve": "^3.0.6",
     "@types/html-minifier": "^3.5.3",

--- a/packages/webpack-plugin/src/plugins/shim/meta.ts
+++ b/packages/webpack-plugin/src/plugins/shim/meta.ts
@@ -1,6 +1,14 @@
 // the `meta.ts` is used for compiling and the `patches/index.ts` is used for runtime
 
-export const patchedVariables = ['Function', 'Promise', 'String', 'getCurrentPages'];
+export const patchedVariables = [
+  'Function',
+  'Promise',
+  'String',
+  'Array',
+  'ArrayBuffer',
+  'Number',
+  'getCurrentPages',
+];
 
 export const undefinedVariables = [
   'window',

--- a/packages/webpack-plugin/src/plugins/shim/patches/array.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/array.ts
@@ -1,0 +1,39 @@
+const OriginalArray = Array;
+
+const patchArray = () => {
+  const PatchedArray = function Array<T>(this: any, value: any): Array<T> {
+    let instance: Array<T>;
+    if (this instanceof PatchedArray || this instanceof OriginalArray) {
+      // @ts-ignore
+      instance = new OriginalArray(value);
+    } else {
+      instance = OriginalArray(value);
+    }
+    Object.setPrototypeOf(instance, PatchedArray.prototype);
+
+    return instance;
+  };
+
+  // inherit `Array.prototype`
+  PatchedArray.prototype = Object.create(OriginalArray.prototype, {
+    constructor: { enumerable: false, writable: true, configurable: true, value: PatchedArray },
+  });
+
+  // inherit `Array` members
+  Object.setPrototypeOf(PatchedArray, OriginalArray);
+
+  // support `instanceof Array`
+  // may not work on old browsers like iOS < 9 and Android < 5
+  if (typeof Symbol !== 'undefined' && Symbol.hasInstance) {
+    Object.defineProperty(PatchedArray, Symbol.hasInstance, {
+      enumerable: false,
+      writable: true,
+      configurable: true,
+      value: (left: any): boolean => left instanceof OriginalArray,
+    });
+  }
+
+  return PatchedArray;
+};
+
+module.exports = patchArray();

--- a/packages/webpack-plugin/src/plugins/shim/patches/arrayBuffer.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/arrayBuffer.ts
@@ -1,0 +1,41 @@
+const OriginalArrayBuffer = ArrayBuffer;
+
+const patchArrayBuffer = () => {
+  const PatchedArrayBuffer = function ArrayBuffer(this: any, byteLength: number): ArrayBuffer {
+    if (!(this instanceof PatchedArrayBuffer || this instanceof OriginalArrayBuffer)) {
+      throw new TypeError('Cannot call a class as a function');
+    }
+    const instance = new OriginalArrayBuffer(byteLength);
+    Object.setPrototypeOf(instance, PatchedArrayBuffer.prototype);
+
+    return instance;
+  };
+
+  // inherit `ArrayBuffer.prototype`
+  PatchedArrayBuffer.prototype = Object.create(OriginalArrayBuffer.prototype, {
+    constructor: {
+      enumerable: false,
+      writable: true,
+      configurable: true,
+      value: PatchedArrayBuffer,
+    },
+  });
+
+  // inherit `ArrayBuffer` members
+  Object.setPrototypeOf(PatchedArrayBuffer, OriginalArrayBuffer);
+
+  // support `instanceof ArrayBuffer`
+  // may not work on old browsers like iOS < 9 and Android < 5
+  if (typeof Symbol !== 'undefined' && Symbol.hasInstance) {
+    Object.defineProperty(PatchedArrayBuffer, Symbol.hasInstance, {
+      enumerable: false,
+      writable: true,
+      configurable: true,
+      value: (left: any): boolean => left instanceof OriginalArrayBuffer,
+    });
+  }
+
+  return PatchedArrayBuffer;
+};
+
+module.exports = patchArrayBuffer();

--- a/packages/webpack-plugin/src/plugins/shim/patches/index.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/index.ts
@@ -10,6 +10,9 @@ module.exports = {
   Function: require('./function'),
   Promise: require('./promise'),
   String: require('./string'),
+  Array: require('./array'),
+  ArrayBuffer: require('./arrayBuffer'),
+  Number: require('./number'),
   getCurrentPages: require('./getCurrentPages'),
   /* eslint-enable global-require */
 

--- a/packages/webpack-plugin/src/plugins/shim/patches/number.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/number.ts
@@ -1,0 +1,43 @@
+const OriginalNumber = Number;
+
+const patchNumber = () => {
+  const PatchedNumber = function Number(this: any, value: any): Number {
+    let instance: Number;
+    if (this instanceof PatchedNumber || this instanceof OriginalNumber) {
+      instance = new OriginalNumber(value);
+    } else {
+      instance = OriginalNumber(value);
+    }
+    Object.setPrototypeOf(instance, PatchedNumber.prototype);
+
+    return instance;
+  };
+
+  // inherit `Number.prototype`
+  PatchedNumber.prototype = Object.create(OriginalNumber.prototype, {
+    constructor: {
+      enumerable: false,
+      writable: true,
+      configurable: true,
+      value: PatchedNumber,
+    },
+  });
+
+  // inherit `Number` members
+  Object.setPrototypeOf(PatchedNumber, OriginalNumber);
+
+  // support `instanceof Number`
+  // may not work on old browsers like iOS < 9 and Android < 5
+  if (typeof Symbol !== 'undefined' && Symbol.hasInstance) {
+    Object.defineProperty(PatchedNumber, Symbol.hasInstance, {
+      enumerable: false,
+      writable: true,
+      configurable: true,
+      value: (left: any): boolean => left instanceof OriginalNumber,
+    });
+  }
+
+  return PatchedNumber;
+};
+
+module.exports = patchNumber();


### PR DESCRIPTION
> This PR copies code from internal repo to pubic repo.

1. Upgrade version to 0.7.6

2. Patch `Array`, `Number`, `ArrayBuffer` in the GojiShimPlugin 