### PR TITLE
Fix target for webpack config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,8 @@ const main = async () => {
     console.error(error.message);
     return;
   }
+  // re-patch NODE_ENV for `babel.config.ts`
+  process.env.NODE_ENV = cliConfig.production ? 'production' : 'development';
   const gojiConfig = requireGojiConfig(basedir);
   // eslint-disable-next-line global-require
   const babelConfig = require('./config/babel.config');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,6 @@
 import webpack from 'webpack';
 import resolve from 'resolve';
 import path from 'path';
-import { GojiTarget } from '@goji/core';
 import { getWebpackConfig } from './config/webpack.config';
 import { parseArgv, CliConfig } from './argv';
 
@@ -31,32 +30,6 @@ const requireGojiConfig = (basedir: string): GojiConfig => {
   return require(resolvedPath);
 };
 
-const getInitialWebpackConfig = ({
-  outputPath,
-  integrationMode,
-  componentWhitelist,
-  babelConfig,
-}: {
-  outputPath?: string;
-  integrationMode: boolean;
-  componentWhitelist: Array<string> | undefined;
-  babelConfig: any;
-}) => {
-  const basedir = process.env.PWD!;
-  const target = (process.env.TARGET || 'wechat') as GojiTarget;
-  const nodeEnv = process.env.NODE_ENV || 'development';
-
-  return getWebpackConfig({
-    basedir,
-    outputPath,
-    target,
-    nodeEnv,
-    babelConfig,
-    unsafe_integrationMode: integrationMode,
-    unstable_componentWhitelist: componentWhitelist,
-  });
-};
-
 const main = async () => {
   const basedir = process.env.PWD!;
   let cliConfig: CliConfig;
@@ -72,11 +45,14 @@ const main = async () => {
   if (gojiConfig.configureBabel) {
     gojiConfig.configureBabel(babelConfig);
   }
-  const webpackConfig = getInitialWebpackConfig({
+  const webpackConfig = getWebpackConfig({
+    basedir,
     outputPath: gojiConfig.outputPath,
+    target: cliConfig.target,
+    nodeEnv: cliConfig.production ? 'production' : 'development',
     babelConfig,
-    integrationMode: gojiConfig.unsafe_integrationMode ?? false,
-    componentWhitelist: gojiConfig.unstable_componentWhitelist,
+    unsafe_integrationMode: gojiConfig.unsafe_integrationMode ?? false,
+    unstable_componentWhitelist: gojiConfig.unstable_componentWhitelist,
   });
 
   // apply goji.config.js configureWebpack


### PR DESCRIPTION
Since we began using `@goji/cli` the right way to pass `target` and `nodeEnv` to Webpack is 

`yarn <start or build> [target]`.

If you run `yarn start`, the `nodeEnv` should be `development`.

If you run `yarn build alipay, the `nodeEnv` should be `development` and `target` should be `alipay`.