### PR TITLE
Collect used components while compling

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -43,7 +43,6 @@ export const getWebpackConfig = ({
   nodeEnv,
   babelConfig,
   unsafe_integrationMode: integrationMode = false,
-  unstable_componentWhitelist: componentWhitelist,
 }: {
   basedir: string;
   outputPath?: string;
@@ -52,8 +51,6 @@ export const getWebpackConfig = ({
   babelConfig: any;
   // eslint-disable-next-line camelcase
   unsafe_integrationMode?: boolean;
-  // eslint-disable-next-line camelcase
-  unstable_componentWhitelist?: Array<string>;
 }): webpack.Configuration => {
   const cacheLoaders = getCacheLoader(
     nodeEnv === 'production',
@@ -193,7 +190,6 @@ export const getWebpackConfig = ({
         maxDepth: 5,
         minimize: nodeEnv !== 'development',
         unsafe_integrationMode: integrationMode,
-        unstable_componentWhitelist: componentWhitelist,
       }),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(nodeEnv),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,8 +11,6 @@ interface GojiConfig {
   configureBabel?: (config: any) => any;
   progress?: boolean;
   // eslint-disable-next-line camelcase
-  unstable_componentWhitelist?: Array<string>;
-  // eslint-disable-next-line camelcase
   unsafe_integrationMode?: boolean;
 }
 
@@ -54,7 +52,6 @@ const main = async () => {
     nodeEnv: cliConfig.production ? 'production' : 'development',
     babelConfig,
     unsafe_integrationMode: gojiConfig.unsafe_integrationMode ?? false,
-    unstable_componentWhitelist: gojiConfig.unstable_componentWhitelist,
   });
 
   // apply goji.config.js configureWebpack

--- a/packages/core/src/components/factoryComponents.ts
+++ b/packages/core/src/components/factoryComponents.ts
@@ -506,26 +506,12 @@ interface BuildInComponentsProps {
 
 type BuildInComponents = keyof BuildInComponentsProps;
 
-const warnedWhitelistSet = process.env.NODE_ENV !== 'production' ? new Set<string>() : undefined;
-
 const factoryComponent = <T extends BuildInComponents, P extends BuildInComponentsProps[T]>(
   component: T,
 ) => {
   const displayName = pascalCase(component);
   // FIXME: Not all components have `children`. We should fix the type later.
   const comp = (props: P, ref: React.Ref<PublicInstance>) => {
-    // warning if whitelist doesn't contain this component in dev mode
-    if (process.env.NODE_ENV !== 'production' && process.env.GOJI_COMPONENT_WHITELIST) {
-      if (
-        !process.env.GOJI_COMPONENT_WHITELIST.includes(component) &&
-        !warnedWhitelistSet!.has(component)
-      ) {
-        warnedWhitelistSet!.add(component);
-        console.warn(
-          `Component <${displayName}> was not included in component whitelist.\nPlease add \`${component}\` to \`unstable_componentWhitelist\` in GojiWebpackPlugin options.`,
-        );
-      }
-    }
     return createElement(component, { ...props, ref });
   };
 

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { GojiShimPlugin } from './plugins/shim';
 import { getPoll } from './utils/polling';
 import { GojiProjectConfigPlugin } from './plugins/projectConfig';
+import { GojiCollectUsedComponentsWebpackPlugin } from './plugins/collectUsedComponents';
 
 export class GojiWebpackPlugin implements webpack.Plugin {
   private options: GojiWebpackPluginOptions;
@@ -29,9 +30,9 @@ export class GojiWebpackPlugin implements webpack.Plugin {
     new webpack.DefinePlugin({
       'process.env.TARGET': JSON.stringify(options.target),
       'process.env.GOJI_TARGET': JSON.stringify(options.target),
-      'process.env.GOJI_COMPONENT_WHITELIST': JSON.stringify(options.unstable_componentWhitelist),
       'process.env.GOJI_MAX_DEPTH': JSON.stringify(options.maxDepth),
     }).apply(compiler);
+    new GojiCollectUsedComponentsWebpackPlugin(options).apply(compiler);
     new GojiBridgeWebpackPlugin(options).apply(compiler);
     new GojiEntryWebpackPlugin(options).apply(compiler);
     new GojiSplitChunksWebpackPlugin(options).apply(compiler);

--- a/packages/webpack-plugin/src/plugins/collectUsedComponents.ts
+++ b/packages/webpack-plugin/src/plugins/collectUsedComponents.ts
@@ -1,0 +1,101 @@
+/* eslint-disable no-await-in-loop */
+import webpack from 'webpack';
+import kebabCase from 'lodash/kebabCase';
+import { GojiBasedWebpackPlugin } from './based';
+import { usedComponentsMap } from '../shared';
+
+const GOJI_CORE_PACKAGE_NAME = '@goji/core';
+
+// hard code string in Webpack
+// https://github.com/webpack/webpack/blob/8d5ad83b3274029e37386dbd5d0c64d8102bcd6f/lib/dependencies/HarmonyImportSpecifierDependency.js#L36
+const HARMONY_IMPORT_SPECIFIER_DEPENDENCY_TYPE: webpack.Stats.ReasonType =
+  'harmony import specifier';
+// https://github.com/webpack/webpack/blob/8d5ad83b3274029e37386dbd5d0c64d8102bcd6f/lib/dependencies/CommonJsRequireDependency.js#L16
+const COMMON_JS_REQUIRE_DEPENDENCY_TYPE: webpack.Stats.ReasonType = 'cjs require';
+
+interface WebpackCompilationDependency {
+  type: webpack.Stats.ReasonType;
+  request: string;
+  name: string;
+  id: string | null;
+}
+
+interface WebpackCompilationModule {
+  type: string;
+  resource: string;
+  dependencies: Array<WebpackCompilationDependency>;
+}
+
+const isUpperCase = (char: string) => char.toUpperCase() === char;
+
+/*
+ * 1. filter component-like name, e.g. CoverView
+ * 2. convert it to kebab case, e.g. CoverView => cover-view
+ */
+const formatUsedComponents = (names: Array<string>): Array<string> => {
+  return names.filter(name => isUpperCase(name[0])).map(name => kebabCase(name));
+};
+
+/**
+ * collect used component by analyzing Webpack dependency tree for GojiBridgeWebpackPlugin
+ * for example, if use `import { View, Button, Image } from '@goji/core'`
+ * GojiJS should output only <view>, <button> and <image> in bridge files
+ */
+export class GojiCollectUsedComponentsWebpackPlugin extends GojiBasedWebpackPlugin {
+  public apply(compiler: webpack.Compiler) {
+    compiler.hooks.thisCompilation.tap('GojiCollectUsedComponentsWebpackPlugin', compilation => {
+      // should use `afterChunks` which run before `optimize` because `optimize` break original dependencies
+      // @ts-ignore
+      compilation.hooks.afterChunks.tap('GojiCollectUsedComponentsWebpackPlugin', () => {
+        const collectDependencyOfGojiCore = (
+          modules: Array<WebpackCompilationModule>,
+        ): Array<string> | undefined => {
+          const dependencyNamesSet = new Set<string>();
+          for (const module of modules) {
+            if (module.type.startsWith('javascript/')) {
+              for (const dependency of module.dependencies) {
+                // only process `@goji/core`
+                if (dependency.request !== GOJI_CORE_PACKAGE_NAME) {
+                  continue;
+                }
+                switch (dependency.type) {
+                  case COMMON_JS_REQUIRE_DEPENDENCY_TYPE: {
+                    compilation.warnings.push(
+                      new Error(
+                        `[GojiCollectUsedComponentsWebpackPlugin] \nGojiJS strongly recommend to use ES module in ${module.resource} otherwise the bridge file size optimization was disabled`,
+                      ),
+                    );
+                    return undefined;
+                  }
+                  case HARMONY_IMPORT_SPECIFIER_DEPENDENCY_TYPE: {
+                    // `dependency.id` would be `null` if this is a namespace import, which means `import * as xx from 'yy'`
+                    // see https://github.com/webpack/webpack/blob/8d5ad83b3274029e37386dbd5d0c64d8102bcd6f/lib/Parser.js#L1210
+                    if (!dependency.id) {
+                      compilation.warnings.push(
+                        new Error(
+                          `[GojiCollectUsedComponentsWebpackPlugin] \nShould not use \`import * as ${dependency.name} from '@goji/core'\` in ${module.resource}`,
+                        ),
+                      );
+                      return undefined;
+                    }
+                    dependencyNamesSet.add(dependency.id);
+                    break;
+                  }
+                  default:
+                    break;
+                }
+              }
+            }
+          }
+
+          return Array.from(dependencyNamesSet);
+        };
+        const dependencyNames = collectDependencyOfGojiCore(compilation.modules);
+        usedComponentsMap.set(
+          compilation,
+          dependencyNames ? formatUsedComponents(dependencyNames) : undefined,
+        );
+      });
+    });
+  }
+}

--- a/packages/webpack-plugin/src/shared/index.ts
+++ b/packages/webpack-plugin/src/shared/index.ts
@@ -4,3 +4,7 @@ import { AppConfig } from '../types';
 export const appConfigMap = new WeakMap<webpack.Compiler, AppConfig>();
 export const appEntryMap = new WeakMap<webpack.Compiler, string>();
 export const pathEntriesMap = new WeakMap<webpack.Compiler, Array<string>>();
+export const usedComponentsMap = new WeakMap<
+  webpack.compilation.Compilation,
+  Array<string> | undefined
+>();

--- a/packages/webpack-plugin/src/types/index.ts
+++ b/packages/webpack-plugin/src/types/index.ts
@@ -8,8 +8,6 @@ export interface GojiWebpackPluginOptions {
   // we should remove it after GojiJS fully migrated
   // eslint-disable-next-line camelcase
   unsafe_integrationMode?: boolean;
-  // eslint-disable-next-line camelcase
-  unstable_componentWhitelist?: Array<string>;
 }
 
 export interface AppSubpackage {


### PR DESCRIPTION
# Why

The bridge files look like this,

```html
<block wx:elif="{{type === 'button'}}">
<button
  data-goji-id="{{id || -1}}"
  class="{{props.className}}"
  style="{{props.style || ''}}"
  ...
>xxx</button>
</block>
<block wx:elif="{{type === 'camera'}}">
  <camera>...</camera>
</block>
```

Normally, GojiJS generates all components in bridge files. It may cause bridge files too large that exceeds the 2MB main package limitation. For reducing the bundle size, GojiJS use an unstable config file `unstable_componentWhitelist` to filter the needed components.

```js
// goji.config.js
module.exports = {
  unstable_componentWhitelist: ['view', 'button']
}
```
Of course, it's un-scalable and hard to maintain in a large project such as Airbnb.

# What

This PR removed the `unstable_componentWhitelist`. And use static analyzing to auto-generate such component filter.

# How

A new plguin `GojiCollectUsedComponentsWebpackPlugin` collects the `import` statement of `@goji/core` into `usedComponentMap`, then `GojiBridgeWebpackPlugin` filters the components by that data.

This solution uses the Webpack dependencies system, and no extra AST parser is needed. 

```
source code 
=> 
Webpack ES parser (acorn) 
=> 
AST 
=> 
Webpack JavascriptModulesPlugin
=> 
modules and dependencies 
=> 
GojiCollectUsedComponentsWebpackPlugin
=> 
usedComponent (Array<string>)
=> 
GojiBridgeWebpackPlugin
=>
output bridge files
```

> After researching I think [babel-plugin-macro](https://github.com/kentcdodds/babel-plugin-macros) is not suitable here because
> 1. Babel macro should be pure otherwise may not be compatible with `cache-loader`
> 2. It's hard to send data between loader instances in different threads however GojiJS use `thread-loader` to process babel-loader.
> 3. Babel macro cost more computing resources to parse and analyze AST although Webpack already done.