### PR TITLE
Refactor wrapped components to support all platforms

### DIFF
--- a/packages/core/src/reconciler/__tests__/instance.test.tsx
+++ b/packages/core/src/reconciler/__tests__/instance.test.tsx
@@ -51,6 +51,8 @@ describe('ElementInstance', () => {
   });
 
   describe('getSubtreeId', () => {
+    // @ts-ignore
+    process.env.GOJI_WRAPPED_COMPONENTS = [];
     const view = () =>
       new ElementInstance('view', {}, [], new Container(new TestingAdaptorInstance()));
     const subtree = () =>

--- a/packages/core/src/reconciler/instance.ts
+++ b/packages/core/src/reconciler/instance.ts
@@ -8,7 +8,7 @@ import { shallowEqual } from '../utils/shallowEqual';
 import { subtreeMaxDepth } from '../components/subtree';
 import { batchedUpdates } from '.';
 
-// prop types from BUILD_IN_COMPONENTS
+// prop types from ComponentDesc
 export type PuredValue = undefined | null | boolean | number | string | object | Array<any>;
 export type Updates = Record<string, PuredValue | ElementNode | TextNode>;
 export type InstanceProps = Record<string, any>;
@@ -87,8 +87,10 @@ export class ElementInstance extends BaseInstance {
 
   public getSubtreeId(): number | undefined {
     // wrapped component should return its wrapper as subtree id
-    // FIXME: how to find a better way to share config between @goji/core and @goji/webpack-plugin ?
-    if (['input', 'textarea', 'map', 'scroll-view', 'swiper', 'swiper-item'].includes(this.type)) {
+    // `process.env.GOJI_WRAPPED_COMPONENTS` is generated from `@goji/webpack-plugin` to tell which
+    // components are wrapped as custom components
+    const wrappedComponentsFromWebpack: Array<string> = process.env.GOJI_WRAPPED_COMPONENTS as any;
+    if (wrappedComponentsFromWebpack.includes(this.type)) {
       return this.id;
     }
     const ancestors: Array<ElementInstance> = [];
@@ -104,11 +106,7 @@ export class ElementInstance extends BaseInstance {
         return undefined;
       }
       // wrapped component creates a new subtree
-      // FIXME: how to find a better way to share config between @goji/core and @goji/webpack-plugin ?
-      if (
-        cursor.type === TYPE_SUBTREE ||
-        ['scroll-view', 'swiper', 'swiper-item'].includes(cursor.type)
-      ) {
+      if (cursor.type === TYPE_SUBTREE || wrappedComponentsFromWebpack.includes(cursor.type)) {
         topGojiId = cursor.id;
         break;
       }

--- a/packages/webpack-plugin/src/constants/__tests__/components.test.ts
+++ b/packages/webpack-plugin/src/constants/__tests__/components.test.ts
@@ -1,13 +1,15 @@
-import { BUILD_IN_COMPONENTS } from '../components';
+import { getBuiltInComponents } from '../components';
+
+const builtInComponents = getBuiltInComponents('wechat');
 
 describe('components', () => {
-  describe('BUILD_IN_COMPONENTS', () => {
+  describe('getBuiltInComponents', () => {
     it('is an array', () => {
-      expect(BUILD_IN_COMPONENTS).toBeInstanceOf(Array);
+      expect(builtInComponents).toBeInstanceOf(Array);
     });
     it('has a definite list of built-in tags', () => {
       expect(
-        BUILD_IN_COMPONENTS.map(({ name }) => name).sort((a, b) => a.localeCompare(b)),
+        builtInComponents.map(({ name }) => name).sort((a, b) => a.localeCompare(b)),
       ).toStrictEqual([
         'ad',
         'audio',

--- a/packages/webpack-plugin/src/constants/components.ts
+++ b/packages/webpack-plugin/src/constants/components.ts
@@ -1,3 +1,5 @@
+import { GojiTarget } from '@goji/core';
+
 // sort compnents to import `wx:elif` performance
 const sortComponents = component => {
   // FIXME: list not finished
@@ -59,1365 +61,1380 @@ export type ComponentDesc = {
 };
 
 // docs: https://developers.weixin.qq.com/miniprogram/en/dev/component/
-export const BUILD_IN_COMPONENTS: ComponentDesc[] = sortComponents(
-  addCommonEvents([
-    // View Container
-    {
-      name: 'movable-view',
-      props: {
-        direction: {
-          type: propTypes.string,
-          value: 'none',
+export const getBuiltInComponents = (target: GojiTarget): ComponentDesc[] =>
+  sortComponents(
+    addCommonEvents([
+      // View Container
+      {
+        name: 'movable-view',
+        props: {
+          direction: {
+            type: propTypes.string,
+            value: 'none',
+          },
+          inertia: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'out-of-bounds': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          x: {
+            type: propTypes.number,
+          },
+          y: {
+            type: propTypes.number,
+          },
+          damping: {
+            type: propTypes.number,
+            value: 20,
+          },
+          friction: {
+            type: propTypes.number,
+            value: 2,
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          scale: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'scale-min': {
+            type: propTypes.number,
+            value: 0.5,
+          },
+          'scale-max': {
+            type: propTypes.number,
+            value: 10,
+          },
+          'scale-value': {
+            type: propTypes.number,
+            value: 1,
+          },
+          animation: {
+            type: propTypes.boolean,
+            value: true,
+          },
         },
-        inertia: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'out-of-bounds': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        x: {
-          type: propTypes.number,
-        },
-        y: {
-          type: propTypes.number,
-        },
-        damping: {
-          type: propTypes.number,
-          value: 20,
-        },
-        friction: {
-          type: propTypes.number,
-          value: 2,
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        scale: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'scale-min': {
-          type: propTypes.number,
-          value: 0.5,
-        },
-        'scale-max': {
-          type: propTypes.number,
-          value: 10,
-        },
-        'scale-value': {
-          type: propTypes.number,
-          value: 1,
-        },
-        animation: {
-          type: propTypes.boolean,
-          value: true,
-        },
+        events: [
+          'change',
+          'scale',
+          // FIXME: `htouchmove` and `vtouchmove` are not prefixed with bind
+          'htouchmove',
+          'vtouchmove',
+        ],
       },
-      events: [
-        'change',
-        'scale',
-        // FIXME: `htouchmove` and `vtouchmove` are not prefixed with bind
-        'htouchmove',
-        'vtouchmove',
-      ],
-    },
-    {
-      name: 'cover-image',
-      props: {
-        src: {
-          type: propTypes.string,
+      {
+        name: 'cover-image',
+        props: {
+          src: {
+            type: propTypes.string,
+          },
         },
+        events: ['load', 'error'],
       },
-      events: ['load', 'error'],
-    },
-    {
-      name: 'cover-view',
-      props: {
-        'scroll-top': {
-          type: [propTypes.string, propTypes.number],
+      {
+        name: 'cover-view',
+        props: {
+          'scroll-top': {
+            type: [propTypes.string, propTypes.number],
+          },
         },
-      },
 
-      events: [],
-    },
-    {
-      name: 'movable-area',
-      props: {
-        'scale-area': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: [],
       },
-      events: [],
-    },
-    {
-      name: 'scroll-view',
-      isWrapped: true,
-      props: {
-        'scroll-x': {
-          type: propTypes.boolean,
-          value: false,
+      {
+        name: 'movable-area',
+        props: {
+          'scale-area': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        'scroll-y': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'upper-threshold': {
-          type: [propTypes.number, propTypes.string],
-          value: 50,
-        },
-        'lower-threshold': {
-          type: [propTypes.number, propTypes.string],
-          value: 50,
-        },
-        'scroll-top': {
-          type: [propTypes.number, propTypes.string],
-        },
-        'scroll-left': {
-          type: [propTypes.number, propTypes.string],
-        },
-        'scroll-into-view': {
-          type: propTypes.string,
-        },
-        'scroll-with-animation': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-back-to-top': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-flex': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'scroll-anchoring': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: [],
       },
-      events: ['scroll-to-upper', 'scroll-to-lower', 'scroll'],
-    },
-    {
-      name: 'swiper',
-      isWrapped: true,
-      props: {
-        'indicator-dots': {
-          type: propTypes.boolean,
-          value: false,
+      {
+        name: 'scroll-view',
+        isWrapped: ['wechat', 'qq'].includes(target),
+        props: {
+          'scroll-x': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'scroll-y': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'upper-threshold': {
+            type: [propTypes.number, propTypes.string],
+            value: 50,
+          },
+          'lower-threshold': {
+            type: [propTypes.number, propTypes.string],
+            value: 50,
+          },
+          'scroll-top': {
+            type: [propTypes.number, propTypes.string],
+          },
+          'scroll-left': {
+            type: [propTypes.number, propTypes.string],
+          },
+          'scroll-into-view': {
+            type: propTypes.string,
+          },
+          'scroll-with-animation': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-back-to-top': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-flex': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'scroll-anchoring': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        'indicator-color': {
-          type: propTypes.color,
-          value: 'rgba(0,0,0,.3)',
-        },
-        'indicator-active-color': {
-          type: propTypes.color,
-          value: '#000000',
-        },
-        autoplay: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        current: {
-          type: propTypes.number,
-          value: 0,
-        },
-        interval: {
-          type: propTypes.number,
-          value: 5000,
-        },
-        duration: {
-          type: propTypes.number,
-          value: 500,
-        },
-        circular: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        vertical: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'previous-margin': {
-          type: propTypes.string,
-          value: '0px',
-        },
-        'next-margin': {
-          type: propTypes.string,
-          value: '0px',
-        },
-        'display-multiple-items': {
-          type: propTypes.number,
-          value: 1,
-        },
-        'skip-hidden-item-layout': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'easing-function': {
-          type: propTypes.string,
-          value: 'default',
-        },
+        events: ['scroll-to-upper', 'scroll-to-lower', 'scroll'],
       },
-      events: ['change', 'transition', 'animationfinish'],
-    },
-    {
-      name: 'swiper-item',
-      props: {
-        'item-id': {
-          type: propTypes.string,
+      {
+        name: 'swiper',
+        isWrapped: ['wechat', 'qq'].includes(target),
+        props: {
+          'indicator-dots': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'indicator-color': {
+            type: propTypes.color,
+            value: 'rgba(0,0,0,.3)',
+          },
+          'indicator-active-color': {
+            type: propTypes.color,
+            value: '#000000',
+          },
+          autoplay: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          current: {
+            type: propTypes.number,
+            value: 0,
+          },
+          interval: {
+            type: propTypes.number,
+            value: 5000,
+          },
+          duration: {
+            type: propTypes.number,
+            value: 500,
+          },
+          circular: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          vertical: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'previous-margin': {
+            type: propTypes.string,
+            value: '0px',
+          },
+          'next-margin': {
+            type: propTypes.string,
+            value: '0px',
+          },
+          'display-multiple-items': {
+            type: propTypes.number,
+            value: 1,
+          },
+          'skip-hidden-item-layout': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'easing-function': {
+            type: propTypes.string,
+            value: 'default',
+          },
         },
+        events: ['change', 'transition', 'animationfinish'],
       },
-      events: [],
-    },
-    {
-      name: 'text',
-      props: {
-        selectable: {
-          type: propTypes.boolean,
-          value: false,
+      {
+        name: 'swiper-item',
+        props: {
+          'item-id': {
+            type: propTypes.string,
+          },
         },
-        space: {
-          type: propTypes.string,
-        },
-        decode: {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: [],
       },
-      events: [],
-    },
-    // Basic Content
-    {
-      name: 'icon',
-      props: {
-        type: {
-          type: propTypes.string,
-          required: true,
+      {
+        name: 'text',
+        props: {
+          selectable: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          space: {
+            type: propTypes.string,
+          },
+          decode: {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        size: {
-          type: [propTypes.number, propTypes.string],
-          value: 23,
-        },
-        color: {
-          type: propTypes.string,
-        },
+        events: [],
       },
-      events: [],
-      isLeaf: true,
-    },
-    {
-      name: 'progress',
-      props: {
-        percent: {
-          type: propTypes.number,
+      // Basic Content
+      {
+        name: 'icon',
+        props: {
+          type: {
+            type: propTypes.string,
+            required: true,
+          },
+          size: {
+            type: [propTypes.number, propTypes.string],
+            value: 23,
+          },
+          color: {
+            type: propTypes.string,
+          },
         },
-        'show-info': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'border-radius': {
-          type: [propTypes.number, propTypes.string],
-          value: 0,
-        },
-        'font-size': {
-          type: [propTypes.number, propTypes.string],
-          value: 16,
-        },
-        'stroke-width': {
-          type: [propTypes.number, propTypes.string],
-          value: 6,
-        },
-        color: {
-          type: propTypes.string,
-          value: '#09BB07',
-        },
-        activeColor: {
-          type: propTypes.string,
-          value: '#09BB07',
-        },
-        backgroundColor: {
-          type: propTypes.string,
-          value: '#EBEBEB',
-        },
-        active: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'active-mode': {
-          type: propTypes.string,
-          value: 'backwards',
-        },
+        events: [],
+        isLeaf: true,
       },
-      events: ['activeend'],
-      isLeaf: true,
-    },
-    {
-      name: 'rich-text',
-      props: {
-        nodes: {
-          type: [propTypes.string, propTypes.array],
-          value: [],
+      {
+        name: 'progress',
+        props: {
+          percent: {
+            type: propTypes.number,
+          },
+          'show-info': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'border-radius': {
+            type: [propTypes.number, propTypes.string],
+            value: 0,
+          },
+          'font-size': {
+            type: [propTypes.number, propTypes.string],
+            value: 16,
+          },
+          'stroke-width': {
+            type: [propTypes.number, propTypes.string],
+            value: 6,
+          },
+          color: {
+            type: propTypes.string,
+            value: '#09BB07',
+          },
+          activeColor: {
+            type: propTypes.string,
+            value: '#09BB07',
+          },
+          backgroundColor: {
+            type: propTypes.string,
+            value: '#EBEBEB',
+          },
+          active: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'active-mode': {
+            type: propTypes.string,
+            value: 'backwards',
+          },
         },
-        space: {
-          type: propTypes.string,
-        },
+        events: ['activeend'],
+        isLeaf: true,
       },
-      events: [],
-    },
-    {
-      name: 'view',
-      props: {
-        'hover-class': {
-          type: propTypes.string,
-          value: 'none',
+      {
+        name: 'rich-text',
+        props: {
+          nodes: {
+            type: [propTypes.string, propTypes.array],
+            value: [],
+          },
+          space: {
+            type: propTypes.string,
+          },
         },
-        'hover-stop-propagation': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'hover-start-time': {
-          type: propTypes.number,
-          value: 50,
-        },
-        'hover-stay-time': {
-          type: propTypes.number,
-          value: 400,
-        },
+        events: [],
       },
-      events: [],
-    },
-    // Form
-    {
-      name: 'button',
-      props: {
-        size: {
-          type: propTypes.string,
-          value: 'default',
+      {
+        name: 'view',
+        props: {
+          'hover-class': {
+            type: propTypes.string,
+            value: 'none',
+          },
+          'hover-stop-propagation': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'hover-start-time': {
+            type: propTypes.number,
+            value: 50,
+          },
+          'hover-stay-time': {
+            type: propTypes.number,
+            value: 400,
+          },
         },
-        type: {
-          type: propTypes.string,
-          // the document said `type` defaults to `'default'` but `''` in fact otherwise the background-color won't work
-          // doc: https://developers.weixin.qq.com/miniprogram/dev/component/button.html
-          value: '',
-        },
-        plain: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        loading: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'form-type': {
-          type: propTypes.string,
-        },
-        'open-type': {
-          type: propTypes.string,
-        },
-        'hover-class': {
-          type: propTypes.string,
-          value: 'button-hover',
-        },
-        'hover-stop-propagation': {
-          type: propTypes.boolean,
-          value: 'false',
-        },
-        'hover-start-time': {
-          type: propTypes.number,
-          value: 20,
-        },
-        'hover-stay-time': {
-          type: propTypes.number,
-          value: 70,
-        },
-        lang: {
-          type: propTypes.string,
-          value: 'en',
-        },
-        'session-from': {
-          type: propTypes.string,
-        },
-        'send-message-title': {
-          type: propTypes.string,
-        },
-        'send-message-path': {
-          type: propTypes.string,
-        },
-        'send-message-img': {
-          type: propTypes.string,
-        },
-        'app-parameter': {
-          type: propTypes.string,
-        },
-        'show-message-card': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: [],
       },
-      events: ['getuserinfo', 'contact', 'getphonenumber', 'error', 'opensetting', 'launchapp'],
-    },
-    {
-      name: 'checkbox',
-      props: {
-        value: {
-          type: propTypes.string,
+      // Form
+      {
+        name: 'button',
+        props: {
+          size: {
+            type: propTypes.string,
+            value: 'default',
+          },
+          type: {
+            type: propTypes.string,
+            // the document said `type` defaults to `'default'` but `''` in fact otherwise the background-color won't work
+            // doc: https://developers.weixin.qq.com/miniprogram/dev/component/button.html
+            value: '',
+          },
+          plain: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          loading: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'form-type': {
+            type: propTypes.string,
+          },
+          'open-type': {
+            type: propTypes.string,
+          },
+          'hover-class': {
+            type: propTypes.string,
+            value: 'button-hover',
+          },
+          'hover-stop-propagation': {
+            type: propTypes.boolean,
+            value: 'false',
+          },
+          'hover-start-time': {
+            type: propTypes.number,
+            value: 20,
+          },
+          'hover-stay-time': {
+            type: propTypes.number,
+            value: 70,
+          },
+          lang: {
+            type: propTypes.string,
+            value: 'en',
+          },
+          'session-from': {
+            type: propTypes.string,
+          },
+          'send-message-title': {
+            type: propTypes.string,
+          },
+          'send-message-path': {
+            type: propTypes.string,
+          },
+          'send-message-img': {
+            type: propTypes.string,
+          },
+          'app-parameter': {
+            type: propTypes.string,
+          },
+          'show-message-card': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        disabled: {
-          type: propTypes.boolean,
-        },
-        checked: {
-          type: propTypes.boolean,
-        },
-        color: {
-          type: propTypes.string,
-          value: '#09BB07',
-        },
+        events: ['getuserinfo', 'contact', 'getphonenumber', 'error', 'opensetting', 'launchapp'],
       },
-      events: [],
-    },
-    {
-      name: 'checkbox-group',
-      props: {},
-      events: ['change'],
-    },
-    {
-      name: 'editor',
-      props: {
-        'read-only': {
-          type: propTypes.boolean,
-          value: false,
+      {
+        name: 'checkbox',
+        props: {
+          value: {
+            type: propTypes.string,
+          },
+          disabled: {
+            type: propTypes.boolean,
+          },
+          checked: {
+            type: propTypes.boolean,
+          },
+          color: {
+            type: propTypes.string,
+            value: '#09BB07',
+          },
         },
-        placeholder: {
-          type: propTypes.string,
-        },
-        'show-img-size': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'show-img-toolbar': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'show-img-resize': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: [],
       },
-      events: ['ready', 'focus', 'blur', 'input', 'statuschange'],
-      isLeaf: true,
-    },
-    {
-      name: 'form',
-      props: {
-        'report-submit': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'report-submit-timeout': {
-          type: propTypes.number,
-          value: 0,
-        },
+      {
+        name: 'checkbox-group',
+        props: {},
+        events: ['change'],
       },
-      events: ['submit', 'reset'],
-    },
-    {
-      name: 'input',
-      isWrapped: true,
-      props: {
-        value: {
-          type: propTypes.string,
-          required: true,
+      {
+        name: 'editor',
+        props: {
+          'read-only': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          placeholder: {
+            type: propTypes.string,
+          },
+          'show-img-size': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'show-img-toolbar': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'show-img-resize': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        type: {
-          type: propTypes.string,
-          value: 'text',
-        },
-        password: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        placeholder: {
-          type: propTypes.string,
-          required: true,
-        },
-        'placeholder-style': {
-          type: propTypes.string,
-          required: true,
-        },
-        'placeholder-class': {
-          type: propTypes.string,
-          value: 'input-placeholder',
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        maxlength: {
-          type: propTypes.number,
-          value: 140,
-        },
-        'cursor-spacing': {
-          type: propTypes.number,
-          value: 0,
-        },
-        'auto-focus': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        focus: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'confirm-type': {
-          type: propTypes.string,
-          value: 'done',
-        },
-        'confirm-hold': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        cursor: {
-          type: propTypes.number,
-          required: true,
-        },
-        'selection-start': {
-          type: propTypes.number,
-          value: -1,
-        },
-        'selection-end': {
-          type: propTypes.number,
-          value: -1,
-        },
-        'adjust-position': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        // Alipay MiniProgram need this prop to fix position of input box is not correct bug.
-        // https://opendocs.alipay.com/mini/component/input
-        enableNative: {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: ['ready', 'focus', 'blur', 'input', 'statuschange'],
+        isLeaf: true,
       },
-      events: ['input', 'focus', 'blur', 'confirm', 'keyboardheightchange'],
-      isLeaf: true,
-    },
-    {
-      name: 'label',
-      props: {
-        for: {
-          type: propTypes.string,
+      {
+        name: 'form',
+        props: {
+          'report-submit': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'report-submit-timeout': {
+            type: propTypes.number,
+            value: 0,
+          },
         },
+        events: ['submit', 'reset'],
       },
-      events: [],
-    },
-    {
-      name: 'picker',
-      props: {
-        mode: {
-          type: propTypes.string,
-          value: 'selector',
+      {
+        name: 'input',
+        isWrapped: ['wechat', 'qq'].includes(target),
+        props: {
+          value: {
+            type: propTypes.string,
+            required: true,
+          },
+          type: {
+            type: propTypes.string,
+            value: 'text',
+          },
+          password: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          placeholder: {
+            type: propTypes.string,
+            required: true,
+          },
+          'placeholder-style': {
+            type: propTypes.string,
+            required: true,
+          },
+          'placeholder-class': {
+            type: propTypes.string,
+            value: 'input-placeholder',
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          maxlength: {
+            type: propTypes.number,
+            value: 140,
+          },
+          'cursor-spacing': {
+            type: propTypes.number,
+            value: 0,
+          },
+          'auto-focus': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          focus: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'confirm-type': {
+            type: propTypes.string,
+            value: 'done',
+          },
+          'confirm-hold': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          cursor: {
+            type: propTypes.number,
+            required: true,
+          },
+          'selection-start': {
+            type: propTypes.number,
+            value: -1,
+          },
+          'selection-end': {
+            type: propTypes.number,
+            value: -1,
+          },
+          'adjust-position': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          // Alipay MiniProgram need this prop to fix position of input box is not correct bug.
+          // https://opendocs.alipay.com/mini/component/input
+          enableNative: {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        range: {
-          type: [propTypes.array, propTypes.object],
-          value: [],
-        },
-        'range-key': {
-          type: propTypes.string,
-        },
-        value: {
-          type: propTypes.number,
-          value: 0,
-        },
-        start: {
-          type: propTypes.string,
-        },
-        end: {
-          type: propTypes.string,
-        },
-        fields: {
-          type: propTypes.string,
-          value: 'day',
-        },
-        'custom-item': {
-          type: propTypes.string,
-        },
+        events: ['input', 'focus', 'blur', 'confirm', 'keyboardheightchange'],
+        isLeaf: true,
       },
-      events: ['cancel', 'change', 'columnchange'],
-    },
-    {
-      name: 'picker-view',
-      props: {
-        value: {
-          type: propTypes.array,
+      {
+        name: 'label',
+        props: {
+          for: {
+            type: propTypes.string,
+          },
         },
-        'indicator-style': {
-          type: propTypes.string,
-        },
-        'indicator-class': {
-          type: propTypes.string,
-        },
-        'mask-style': {
-          type: propTypes.string,
-        },
-        'mask-class': {
-          type: propTypes.string,
-        },
+        events: [],
       },
-      events: ['change', 'pickstart', 'pickend'],
-    },
-    {
-      name: 'picker-view-column',
-      props: {},
-      events: [],
-    },
-    {
-      name: 'radio',
-      props: {
-        value: {
-          type: propTypes.string,
+      {
+        name: 'picker',
+        props: {
+          mode: {
+            type: propTypes.string,
+            value: 'selector',
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          range: {
+            type: [propTypes.array, propTypes.object],
+            value: [],
+          },
+          'range-key': {
+            type: propTypes.string,
+          },
+          value: {
+            type: propTypes.number,
+            value: 0,
+          },
+          start: {
+            type: propTypes.string,
+          },
+          end: {
+            type: propTypes.string,
+          },
+          fields: {
+            type: propTypes.string,
+            value: 'day',
+          },
+          'custom-item': {
+            type: propTypes.string,
+          },
         },
-        checked: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        color: {
-          type: propTypes.string,
-          value: '#09BB07',
-        },
+        events: ['cancel', 'change', 'columnchange'],
       },
-      events: [],
-    },
-    {
-      name: 'radio-group',
-      props: {},
-      events: ['change'],
-    },
-    {
-      name: 'slider',
-      props: {
-        min: {
-          type: propTypes.number,
-          value: 0,
+      {
+        name: 'picker-view',
+        props: {
+          value: {
+            type: propTypes.array,
+          },
+          'indicator-style': {
+            type: propTypes.string,
+          },
+          'indicator-class': {
+            type: propTypes.string,
+          },
+          'mask-style': {
+            type: propTypes.string,
+          },
+          'mask-class': {
+            type: propTypes.string,
+          },
         },
-        max: {
-          type: propTypes.number,
-          value: 100,
-        },
-        step: {
-          type: propTypes.number,
-          value: 1,
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        value: {
-          type: propTypes.number,
-          value: 0,
-        },
-        color: {
-          type: propTypes.color,
-          value: '#e9e9e9',
-        },
-        'selected-color': {
-          type: propTypes.color,
-          value: '#1aad19',
-        },
-        activeColor: {
-          type: propTypes.color,
-          value: '#1aad19',
-        },
-        backgroundColor: {
-          type: propTypes.color,
-          value: '#e9e9e9',
-        },
-        'block-size': {
-          type: propTypes.number,
-          value: 28,
-        },
-        'block-color': {
-          type: propTypes.color,
-          value: '#ffffff',
-        },
-        'show-value': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: ['change', 'pickstart', 'pickend'],
       },
-      events: ['change', 'changing'],
-      isLeaf: true,
-    },
-    {
-      name: 'switch',
-      props: {
-        checked: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        type: {
-          type: propTypes.string,
-          value: 'switch',
-        },
-        color: {
-          type: propTypes.string,
-          value: '#04BE02',
-        },
+      {
+        name: 'picker-view-column',
+        props: {},
+        events: [],
       },
-      events: ['change'],
-      isLeaf: true,
-    },
-    {
-      name: 'textarea',
-      isWrapped: true,
-      props: {
-        value: {
-          type: propTypes.string,
+      {
+        name: 'radio',
+        props: {
+          value: {
+            type: propTypes.string,
+          },
+          checked: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          color: {
+            type: propTypes.string,
+            value: '#09BB07',
+          },
         },
-        placeholder: {
-          type: propTypes.string,
-        },
-        'placeholder-style': {
-          type: propTypes.string,
-        },
-        'placeholder-class': {
-          type: propTypes.string,
-          value: 'textarea-placeholder',
-        },
-        disabled: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        maxlength: {
-          type: propTypes.number,
-          value: 140,
-        },
-        'auto-focus': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        focus: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'auto-height': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        fixed: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'cursor-spacing': {
-          type: propTypes.number,
-          value: 0,
-        },
-        cursor: {
-          type: propTypes.number,
-          value: -1,
-        },
-        'show-confirm-bar': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'selection-start': {
-          type: propTypes.number,
-          value: -1,
-        },
-        'selection-end': {
-          type: propTypes.number,
-          value: -1,
-        },
-        'adjust-position': {
-          type: propTypes.boolean,
-          value: true,
-        },
+        events: [],
       },
-      events: ['focus', 'blur', 'linechange', 'input', 'confirm', 'keyboardheightchange'],
-      isLeaf: true,
-    },
-    // Navigation
-    {
-      name: 'functional-page-navigator',
-      props: {
-        version: {
-          type: propTypes.string,
-          value: 'release',
-        },
-        name: {
-          type: propTypes.string,
-        },
-        args: {
-          type: propTypes.object,
-        },
+      {
+        name: 'radio-group',
+        props: {},
+        events: ['change'],
       },
-      events: ['success', 'fail'],
-    },
-    {
-      name: 'navigator',
-      props: {
-        target: {
-          type: propTypes.string,
-          value: 'self',
+      {
+        name: 'slider',
+        props: {
+          min: {
+            type: propTypes.number,
+            value: 0,
+          },
+          max: {
+            type: propTypes.number,
+            value: 100,
+          },
+          step: {
+            type: propTypes.number,
+            value: 1,
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          value: {
+            type: propTypes.number,
+            value: 0,
+          },
+          color: {
+            type: propTypes.color,
+            value: '#e9e9e9',
+          },
+          'selected-color': {
+            type: propTypes.color,
+            value: '#1aad19',
+          },
+          activeColor: {
+            type: propTypes.color,
+            value: '#1aad19',
+          },
+          backgroundColor: {
+            type: propTypes.color,
+            value: '#e9e9e9',
+          },
+          'block-size': {
+            type: propTypes.number,
+            value: 28,
+          },
+          'block-color': {
+            type: propTypes.color,
+            value: '#ffffff',
+          },
+          'show-value': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        url: {
-          type: propTypes.string,
-        },
-        'open-type': {
-          type: propTypes.string,
-          value: 'navigate',
-        },
-        delta: {
-          type: propTypes.number,
-          value: 1,
-        },
-        'app-id': {
-          type: propTypes.string,
-        },
-        path: {
-          type: propTypes.string,
-        },
-        'extra-data': {
-          type: propTypes.object,
-        },
-        version: {
-          type: propTypes.string,
-          value: 'release',
-        },
-        'hover-class': {
-          type: propTypes.string,
-          value: 'navigator-hover',
-        },
-        'hover-stop-propagation': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'hover-start-time': {
-          type: propTypes.number,
-          value: 50,
-        },
-        'hover-stay-time': {
-          type: propTypes.number,
-          value: 600,
-        },
+        events: ['change', 'changing'],
+        isLeaf: true,
       },
-      events: ['success', 'fail', 'complete'],
-    },
-    // Multimedia
-    {
-      name: 'audio',
-      props: {
-        id: {
-          type: propTypes.string,
+      {
+        name: 'switch',
+        props: {
+          checked: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          type: {
+            type: propTypes.string,
+            value: 'switch',
+          },
+          color: {
+            type: propTypes.string,
+            value: '#04BE02',
+          },
         },
-        src: {
-          type: propTypes.string,
-        },
-        loop: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        controls: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        poster: {
-          type: propTypes.string,
-        },
-        name: {
-          type: propTypes.string,
-          value: '未知音频',
-        },
-        author: {
-          type: propTypes.string,
-          value: '未知作者',
-        },
+        events: ['change'],
+        isLeaf: true,
       },
-      events: ['error', 'play', 'pause', 'timeupdate', 'ended'],
-      isLeaf: true,
-    },
-    {
-      name: 'camera',
-      props: {
-        mode: {
-          type: propTypes.string,
-          value: 'normal',
+      {
+        name: 'textarea',
+        isWrapped: ['wechat', 'qq'].includes(target),
+        props: {
+          value: {
+            type: propTypes.string,
+          },
+          placeholder: {
+            type: propTypes.string,
+          },
+          'placeholder-style': {
+            type: propTypes.string,
+          },
+          'placeholder-class': {
+            type: propTypes.string,
+            value: 'textarea-placeholder',
+          },
+          disabled: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          maxlength: {
+            type: propTypes.number,
+            value: 140,
+          },
+          'auto-focus': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          focus: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'auto-height': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          fixed: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'cursor-spacing': {
+            type: propTypes.number,
+            value: 0,
+          },
+          cursor: {
+            type: propTypes.number,
+            value: -1,
+          },
+          'show-confirm-bar': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'selection-start': {
+            type: propTypes.number,
+            value: -1,
+          },
+          'selection-end': {
+            type: propTypes.number,
+            value: -1,
+          },
+          'adjust-position': {
+            type: propTypes.boolean,
+            value: true,
+          },
         },
-        'device-position': {
-          type: propTypes.string,
-          value: 'back',
-        },
-        flash: {
-          type: propTypes.string,
-          value: 'auto',
-        },
-        'frame-size': {
-          type: propTypes.string,
-          value: 'medium',
-        },
+        events: ['focus', 'blur', 'linechange', 'input', 'confirm', 'keyboardheightchange'],
+        isLeaf: true,
       },
-      events: ['stop', 'error', 'initdone', 'scancode'],
-      isLeaf: true,
-    },
-    {
-      name: 'image',
-      props: {
-        src: {
-          type: propTypes.string,
+      // Navigation
+      {
+        name: 'functional-page-navigator',
+        props: {
+          version: {
+            type: propTypes.string,
+            value: 'release',
+          },
+          name: {
+            type: propTypes.string,
+          },
+          args: {
+            type: propTypes.object,
+          },
         },
-        mode: {
-          type: propTypes.string,
-          value: 'scaleToFill',
-        },
-        'lazy-load': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'show-menu-by-longpress': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: ['success', 'fail'],
       },
-      events: ['error', 'load'],
-      isLeaf: true,
-    },
-    {
-      name: 'live-player',
-      props: {
-        src: {
-          type: propTypes.string,
+      {
+        name: 'navigator',
+        props: {
+          target: {
+            type: propTypes.string,
+            value: 'self',
+          },
+          url: {
+            type: propTypes.string,
+          },
+          'open-type': {
+            type: propTypes.string,
+            value: 'navigate',
+          },
+          delta: {
+            type: propTypes.number,
+            value: 1,
+          },
+          'app-id': {
+            type: propTypes.string,
+          },
+          path: {
+            type: propTypes.string,
+          },
+          'extra-data': {
+            type: propTypes.object,
+          },
+          version: {
+            type: propTypes.string,
+            value: 'release',
+          },
+          'hover-class': {
+            type: propTypes.string,
+            value: 'navigator-hover',
+          },
+          'hover-stop-propagation': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'hover-start-time': {
+            type: propTypes.number,
+            value: 50,
+          },
+          'hover-stay-time': {
+            type: propTypes.number,
+            value: 600,
+          },
         },
-        mode: {
-          type: propTypes.string,
-          value: 'live',
-        },
-        autoplay: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        muted: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        orientation: {
-          type: propTypes.string,
-          value: 'vertical',
-        },
-        'object-fit': {
-          type: propTypes.string,
-          value: 'contain',
-        },
-        'background-mute': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'min-cache': {
-          type: propTypes.number,
-          value: 1,
-        },
-        'max-cache': {
-          type: propTypes.number,
-          value: 3,
-        },
-        'sound-mode': {
-          type: propTypes.string,
-          value: 'speaker',
-        },
-        'auto-pause-if-navigate': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'auto-pause-if-open-native': {
-          type: propTypes.boolean,
-          value: true,
-        },
+        events: ['success', 'fail', 'complete'],
       },
-      events: ['statechange', 'fullscreenchange', 'netstatus'],
-      isLeaf: true,
-    },
-    {
-      name: 'live-pusher',
-      props: {
-        url: {
-          type: propTypes.string,
+      // Multimedia
+      {
+        name: 'audio',
+        props: {
+          id: {
+            type: propTypes.string,
+          },
+          src: {
+            type: propTypes.string,
+          },
+          loop: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          controls: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          poster: {
+            type: propTypes.string,
+          },
+          name: {
+            type: propTypes.string,
+            value: '未知音频',
+          },
+          author: {
+            type: propTypes.string,
+            value: '未知作者',
+          },
         },
-        mode: {
-          type: propTypes.string,
-          value: 'RTC',
-        },
-        autopush: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        muted: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-camera': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'auto-focus': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        orientation: {
-          type: propTypes.string,
-          value: 'vertical',
-        },
-        beauty: {
-          type: propTypes.number,
-          value: 0,
-        },
-        whiteness: {
-          type: propTypes.number,
-          value: 0,
-        },
-        aspect: {
-          type: propTypes.string,
-          value: '9:16',
-        },
-        'min-bitrate': {
-          type: propTypes.number,
-          value: 200,
-        },
-        'max-bitrate': {
-          type: propTypes.number,
-          value: 1000,
-        },
-        'waiting-image': {
-          type: propTypes.string,
-        },
-        'waiting-image-hash': {
-          type: propTypes.string,
-        },
-        zoom: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'device-position': {
-          type: propTypes.string,
-          value: 'front',
-        },
-        'background-mute': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        mirror: {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: ['error', 'play', 'pause', 'timeupdate', 'ended'],
+        isLeaf: true,
       },
-      events: ['statechange', 'netstatus', 'error', 'bgmstart', 'bgmprogress', 'bgmcomplete'],
-      isLeaf: true,
-    },
-    {
-      name: 'video',
-      props: {
-        src: {
-          type: propTypes.string,
-          required: true,
+      {
+        name: 'camera',
+        props: {
+          mode: {
+            type: propTypes.string,
+            value: 'normal',
+          },
+          'device-position': {
+            type: propTypes.string,
+            value: 'back',
+          },
+          flash: {
+            type: propTypes.string,
+            value: 'auto',
+          },
+          'frame-size': {
+            type: propTypes.string,
+            value: 'medium',
+          },
         },
-        duration: {
-          type: propTypes.number,
-        },
-        controls: {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'danmu-list': {
-          type: propTypes.array,
-        },
-        'danmu-btn': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-danmu': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        autoplay: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        loop: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        muted: {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'initial-time': {
-          type: propTypes.number,
-          value: 0,
-        },
-        'page-gesture': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        direction: {
-          type: propTypes.number,
-        },
-        'show-progress': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'show-fullscreen-btn': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'show-play-btn': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'show-center-play-btn': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'enable-progress-gesture': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'object-fit': {
-          type: propTypes.string,
-          value: 'contain',
-        },
-        poster: {
-          type: propTypes.string,
-        },
-        'show-mute-btn': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        title: {
-          type: propTypes.string,
-        },
-        'play-btn-position': {
-          type: propTypes.string,
-          value: 'bottom',
-        },
-        'enable-play-gesture': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'auto-pause-if-navigate': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'auto-pause-if-open-native': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'vslide-gesture': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'vslide-gesture-in-fullscreen': {
-          type: propTypes.boolean,
-          value: true,
-        },
+        events: ['stop', 'error', 'initdone', 'scancode'],
+        isLeaf: true,
       },
-      events: [
-        'play',
-        'pause',
-        'ended',
-        'timeupdate',
-        'fullscreenchange',
-        'waiting',
-        'error',
-        'progress',
-      ],
-      isLeaf: true,
-    },
-    // Map
-    {
-      name: 'map',
-      isWrapped: true,
-      props: {
-        longitude: {
-          type: propTypes.number,
-          required: true,
+      {
+        name: 'image',
+        props: {
+          src: {
+            type: propTypes.string,
+          },
+          mode: {
+            type: propTypes.string,
+            value: 'scaleToFill',
+          },
+          'lazy-load': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'show-menu-by-longpress': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        latitude: {
-          type: propTypes.number,
-          required: true,
-        },
-        scale: {
-          type: propTypes.number,
-          value: 16,
-        },
-        markers: {
-          type: propTypes.array,
-        },
-        // don't support `covers`
-        // 1. covers is deprecated
-        // 2. covers cause map lost uncontrolled data
-        polyline: {
-          type: propTypes.array,
-        },
-        circles: {
-          type: propTypes.array,
-        },
-        controls: {
-          type: propTypes.array,
-        },
-        'include-points': {
-          type: propTypes.array,
-        },
-        'show-location': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        polygons: {
-          type: propTypes.array,
-        },
-        subkey: {
-          type: propTypes.string,
-        },
-        'layer-style': {
-          type: propTypes.number,
-          value: 1,
-        },
-        rotate: {
-          type: propTypes.number,
-          value: 0,
-        },
-        skew: {
-          type: propTypes.number,
-          value: 0,
-        },
-        'enable-3D': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'show-compass': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'show-scale': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-overlooking': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-zoom': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'enable-scroll': {
-          type: propTypes.boolean,
-          value: true,
-        },
-        'enable-rotate': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-satellite': {
-          type: propTypes.boolean,
-          value: false,
-        },
-        'enable-traffic': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: ['error', 'load'],
+        isLeaf: true,
       },
-      events: ['tap', 'markertap', 'controltap', 'callouttap', 'updated', 'regionchange', 'poitap'],
-      isLeaf: true,
-    },
-    // Canvas
-    {
-      name: 'canvas',
-      props: {
-        type: {
-          type: propTypes.string,
+      {
+        name: 'live-player',
+        props: {
+          src: {
+            type: propTypes.string,
+          },
+          mode: {
+            type: propTypes.string,
+            value: 'live',
+          },
+          autoplay: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          muted: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          orientation: {
+            type: propTypes.string,
+            value: 'vertical',
+          },
+          'object-fit': {
+            type: propTypes.string,
+            value: 'contain',
+          },
+          'background-mute': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'min-cache': {
+            type: propTypes.number,
+            value: 1,
+          },
+          'max-cache': {
+            type: propTypes.number,
+            value: 3,
+          },
+          'sound-mode': {
+            type: propTypes.string,
+            value: 'speaker',
+          },
+          'auto-pause-if-navigate': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'auto-pause-if-open-native': {
+            type: propTypes.boolean,
+            value: true,
+          },
         },
-        'canvas-id': {
-          type: propTypes.string,
-        },
-        'disable-scroll': {
-          type: propTypes.boolean,
-          value: false,
-        },
+        events: ['statechange', 'fullscreenchange', 'netstatus'],
+        isLeaf: true,
       },
-      events: ['touchstart', 'touchmove', 'touchend', 'touchcancel', 'longtap', 'error'],
-      isLeaf: true,
-    },
-    // Open Capabilities
-    {
-      name: 'ad',
-      props: {
-        'unit-id': {
-          type: propTypes.string,
-          required: true,
+      {
+        name: 'live-pusher',
+        props: {
+          url: {
+            type: propTypes.string,
+          },
+          mode: {
+            type: propTypes.string,
+            value: 'RTC',
+          },
+          autopush: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          muted: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-camera': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'auto-focus': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          orientation: {
+            type: propTypes.string,
+            value: 'vertical',
+          },
+          beauty: {
+            type: propTypes.number,
+            value: 0,
+          },
+          whiteness: {
+            type: propTypes.number,
+            value: 0,
+          },
+          aspect: {
+            type: propTypes.string,
+            value: '9:16',
+          },
+          'min-bitrate': {
+            type: propTypes.number,
+            value: 200,
+          },
+          'max-bitrate': {
+            type: propTypes.number,
+            value: 1000,
+          },
+          'waiting-image': {
+            type: propTypes.string,
+          },
+          'waiting-image-hash': {
+            type: propTypes.string,
+          },
+          zoom: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'device-position': {
+            type: propTypes.string,
+            value: 'front',
+          },
+          'background-mute': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          mirror: {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
-        'ad-intervals': {
-          type: propTypes.number,
-        },
+        events: ['statechange', 'netstatus', 'error', 'bgmstart', 'bgmprogress', 'bgmcomplete'],
+        isLeaf: true,
       },
-      events: ['load', 'error', 'close'],
-      isLeaf: true,
-    },
-    {
-      name: 'official-account',
-      props: {},
-      events: ['load', 'error'],
-      isLeaf: true,
-    },
-    {
-      name: 'open-data',
-      props: {
-        type: {
-          type: propTypes.string,
+      {
+        name: 'video',
+        props: {
+          src: {
+            type: propTypes.string,
+            required: true,
+          },
+          duration: {
+            type: propTypes.number,
+          },
+          controls: {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'danmu-list': {
+            type: propTypes.array,
+          },
+          'danmu-btn': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-danmu': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          autoplay: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          loop: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          muted: {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'initial-time': {
+            type: propTypes.number,
+            value: 0,
+          },
+          'page-gesture': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          direction: {
+            type: propTypes.number,
+          },
+          'show-progress': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'show-fullscreen-btn': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'show-play-btn': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'show-center-play-btn': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'enable-progress-gesture': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'object-fit': {
+            type: propTypes.string,
+            value: 'contain',
+          },
+          poster: {
+            type: propTypes.string,
+          },
+          'show-mute-btn': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          title: {
+            type: propTypes.string,
+          },
+          'play-btn-position': {
+            type: propTypes.string,
+            value: 'bottom',
+          },
+          'enable-play-gesture': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'auto-pause-if-navigate': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'auto-pause-if-open-native': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'vslide-gesture': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'vslide-gesture-in-fullscreen': {
+            type: propTypes.boolean,
+            value: true,
+          },
         },
-        'open-gid': {
-          type: propTypes.string,
-        },
-        lang: {
-          type: propTypes.string,
-          value: 'en',
-        },
-        'default-text': {
-          type: propTypes.string,
-        },
-        'default-avatar': {
-          type: propTypes.string,
-        },
+        events: [
+          'play',
+          'pause',
+          'ended',
+          'timeupdate',
+          'fullscreenchange',
+          'waiting',
+          'error',
+          'progress',
+        ],
+        isLeaf: true,
       },
-      events: ['error'],
-      isLeaf: true,
-    },
-    {
-      name: 'web-view',
-      props: {
-        src: {
-          type: propTypes.string,
+      // Map
+      {
+        name: 'map',
+        isWrapped: ['wechat', 'qq'].includes(target),
+        props: {
+          longitude: {
+            type: propTypes.number,
+            required: true,
+          },
+          latitude: {
+            type: propTypes.number,
+            required: true,
+          },
+          scale: {
+            type: propTypes.number,
+            value: 16,
+          },
+          markers: {
+            type: propTypes.array,
+          },
+          // don't support `covers`
+          // 1. covers is deprecated
+          // 2. covers cause map lost uncontrolled data
+          polyline: {
+            type: propTypes.array,
+          },
+          circles: {
+            type: propTypes.array,
+          },
+          controls: {
+            type: propTypes.array,
+          },
+          'include-points': {
+            type: propTypes.array,
+          },
+          'show-location': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          polygons: {
+            type: propTypes.array,
+          },
+          subkey: {
+            type: propTypes.string,
+          },
+          'layer-style': {
+            type: propTypes.number,
+            value: 1,
+          },
+          rotate: {
+            type: propTypes.number,
+            value: 0,
+          },
+          skew: {
+            type: propTypes.number,
+            value: 0,
+          },
+          'enable-3D': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'show-compass': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'show-scale': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-overlooking': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-zoom': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'enable-scroll': {
+            type: propTypes.boolean,
+            value: true,
+          },
+          'enable-rotate': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-satellite': {
+            type: propTypes.boolean,
+            value: false,
+          },
+          'enable-traffic': {
+            type: propTypes.boolean,
+            value: false,
+          },
         },
+        events: [
+          'tap',
+          'markertap',
+          'controltap',
+          'callouttap',
+          'updated',
+          'regionchange',
+          'poitap',
+        ],
+        isLeaf: true,
       },
-      events: ['message', 'load', 'error'],
-      isLeaf: true,
-    },
-  ]),
-);
+      // Canvas
+      {
+        name: 'canvas',
+        props: {
+          type: {
+            type: propTypes.string,
+          },
+          'canvas-id': {
+            type: propTypes.string,
+          },
+          'disable-scroll': {
+            type: propTypes.boolean,
+            value: false,
+          },
+        },
+        events: ['touchstart', 'touchmove', 'touchend', 'touchcancel', 'longtap', 'error'],
+        isLeaf: true,
+      },
+      // Open Capabilities
+      {
+        name: 'ad',
+        props: {
+          'unit-id': {
+            type: propTypes.string,
+            required: true,
+          },
+          'ad-intervals': {
+            type: propTypes.number,
+          },
+        },
+        events: ['load', 'error', 'close'],
+        isLeaf: true,
+      },
+      {
+        name: 'official-account',
+        props: {},
+        events: ['load', 'error'],
+        isLeaf: true,
+      },
+      {
+        name: 'open-data',
+        props: {
+          type: {
+            type: propTypes.string,
+          },
+          'open-gid': {
+            type: propTypes.string,
+          },
+          lang: {
+            type: propTypes.string,
+            value: 'en',
+          },
+          'default-text': {
+            type: propTypes.string,
+          },
+          'default-avatar': {
+            type: propTypes.string,
+          },
+        },
+        events: ['error'],
+        isLeaf: true,
+      },
+      {
+        name: 'web-view',
+        props: {
+          src: {
+            type: propTypes.string,
+          },
+        },
+        events: ['message', 'load', 'error'],
+        isLeaf: true,
+      },
+    ]),
+  );
+
+// this function is used for generating a wrapped component list to calculate `getSubtreeId` in `@goji/core`
+export const getWrappedComponents = (target: GojiTarget): Array<string> =>
+  getBuiltInComponents(target)
+    .filter(comp => comp.isWrapped)
+    .map(comp => comp.name);

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -14,6 +14,7 @@ import { GojiShimPlugin } from './plugins/shim';
 import { getPoll } from './utils/polling';
 import { GojiProjectConfigPlugin } from './plugins/projectConfig';
 import { GojiCollectUsedComponentsWebpackPlugin } from './plugins/collectUsedComponents';
+import { getWrappedComponents } from './constants/components';
 
 export class GojiWebpackPlugin implements webpack.Plugin {
   private options: GojiWebpackPluginOptions;
@@ -31,6 +32,7 @@ export class GojiWebpackPlugin implements webpack.Plugin {
       'process.env.TARGET': JSON.stringify(options.target),
       'process.env.GOJI_TARGET': JSON.stringify(options.target),
       'process.env.GOJI_MAX_DEPTH': JSON.stringify(options.maxDepth),
+      'process.env.GOJI_WRAPPED_COMPONENTS': JSON.stringify(getWrappedComponents(options.target)),
     }).apply(compiler);
     new GojiCollectUsedComponentsWebpackPlugin(options).apply(compiler);
     new GojiBridgeWebpackPlugin(options).apply(compiler);

--- a/packages/webpack-plugin/src/utils/__tests__/components.test.ts
+++ b/packages/webpack-plugin/src/utils/__tests__/components.test.ts
@@ -4,13 +4,14 @@ import {
   getWhitelistedComponents,
   getRenderedComponents,
 } from '../components';
-import { BUILD_IN_COMPONENTS } from '../../constants/components';
+import { getBuiltInComponents } from '../../constants/components';
 
 const COMPONENT_WHITELIST = ['view', 'button', 'text', 'invalid-component'];
+const builtInComponents = getBuiltInComponents('wechat');
 
 describe('getWhitelistedComponents', () => {
   test('getWhitelistedComponents works', () => {
-    const whitelistedComponents = getWhitelistedComponents(COMPONENT_WHITELIST);
+    const whitelistedComponents = getWhitelistedComponents('wechat', COMPONENT_WHITELIST);
     expect(whitelistedComponents).toHaveLength(3);
     expect(whitelistedComponents.map(_ => _.name).sort()).toEqual(['button', 'text', 'view']);
   });
@@ -31,7 +32,7 @@ describe('getSimplifiedComponents', () => {
   ];
 
   test('getSimplifiedComponents works', () => {
-    const simplifiedComponents = getSimplifiedComponents(BUILD_IN_COMPONENTS, simplifyComponents);
+    const simplifiedComponents = getSimplifiedComponents(builtInComponents, simplifyComponents);
     expect(simplifiedComponents).toHaveLength(2);
 
     expect(simplifiedComponents[0].name).toBe('view');

--- a/packages/webpack-plugin/src/utils/components.ts
+++ b/packages/webpack-plugin/src/utils/components.ts
@@ -2,14 +2,17 @@ import { unstable_SimplifyComponent as SimplifyComponent, GojiTarget } from '@go
 import camelCase from 'lodash/camelCase';
 import kebabCase from 'lodash/kebabCase';
 import pick from 'lodash/pick';
-import { BUILD_IN_COMPONENTS, ComponentDesc } from '../constants/components';
+import { getBuiltInComponents, ComponentDesc } from '../constants/components';
 
-export const getWhitelistedComponents = (componentWhitelist?: Array<string>): ComponentDesc[] => {
+export const getWhitelistedComponents = (
+  target: GojiTarget,
+  componentWhitelist?: Array<string>,
+): ComponentDesc[] => {
   if (!componentWhitelist) {
-    return BUILD_IN_COMPONENTS;
+    return getBuiltInComponents(target);
   }
 
-  return BUILD_IN_COMPONENTS.filter(comp => componentWhitelist.includes(comp.name));
+  return getBuiltInComponents(target).filter(comp => componentWhitelist.includes(comp.name));
 };
 
 export interface SimplifiedComponentDesc extends ComponentDesc {
@@ -67,7 +70,7 @@ export const getRenderedComponents = (
   simplifyComponents: Array<SimplifyComponent>,
   componentWhitelist?: Array<string>,
 ): Array<ComponentRenderData> => {
-  const components = getWhitelistedComponents(componentWhitelist);
+  const components = getWhitelistedComponents(target, componentWhitelist);
   const renderedComponents: Array<ComponentDesc | SimplifiedComponentDesc> = [
     ...getSimplifiedComponents(components, simplifyComponents),
     ...components,

--- a/packages/webpack-plugin/templates/components.wxml.ejs
+++ b/packages/webpack-plugin/templates/components.wxml.ejs
@@ -92,8 +92,8 @@
 
   <% for (var component of components) {%>
     <block wx:elif="{{<% if (component.sid === undefined) {%>type === '<%= component.name %>'<%} else {%>sid === <%= component.sid %><%}%>}}">
-      <<%= useWrappedComponent && component.isWrapped ? 'goji-' : ''%><%= component.name %>
-      <% if (useWrappedComponent && component.isWrapped) { %>
+      <<%= component.isWrapped ? 'goji-' : ''%><%= component.name %>
+      <% if (component.isWrapped) { %>
         nodes="{{c}}"
         goji-id="{{id || -1}}"
         class-name="{{props.className}}"
@@ -114,7 +114,7 @@
             <%= attribute.name %>="{{props.<%= attribute.value %>}}"
           <% } %>
         <% } %>
-        <% if (useWrappedComponent && component.isWrapped) { %>
+        <% if (component.isWrapped) { %>
           <%# wrapped components will handle event inside themselves %>
         <% } else { %>
           <% for (var event of component.events) {%>
@@ -122,7 +122,7 @@
           <% } %>
         <% } %>
       >
-        <% if (useWrappedComponent && component.isWrapped) { %>
+        <% if (component.isWrapped) { %>
           <%# children will be rendered by `nodes` in the same way the `subtree` does %>
         <% } else { %>
           <% if (inlineChildrenRender) {%>
@@ -133,7 +133,7 @@
             <include src="./children<%= depth %>.wxml" />
           <% } %>
         <% } %>
-      </<%= useWrappedComponent && component.isWrapped ? 'goji-' : ''%><%= component.name %>>
+      </<%= component.isWrapped ? 'goji-' : ''%><%= component.name %>>
     </block>
   <% } %>
   <block wx:else>

--- a/packages/webpack-plugin/templates/components/scroll-view.json.ejs
+++ b/packages/webpack-plugin/templates/components/scroll-view.json.ejs
@@ -1,13 +1,11 @@
 {
   "component": true,
   "usingComponents": {
-    <% if (useWrappedComponent) { %>
-      <% for (const component of components) {%>
-        <% if (component.isWrapped) {%>
-          "goji-<%= component.name %>": "<%= relativePathToBridge %>/<%= component.name %>",
-        <% } %>
-      <% }%>
-    <% } %>
+    <% for (const component of components) {%>
+      <% if (component.isWrapped) {%>
+        "goji-<%= component.name %>": "<%= relativePathToBridge %>/<%= component.name %>",
+      <% } %>
+    <% }%>
 
     "goji-subtree": "<%= relativePathToBridge %>/../subtree"
   }

--- a/packages/webpack-plugin/templates/components/swiper.json.ejs
+++ b/packages/webpack-plugin/templates/components/swiper.json.ejs
@@ -1,13 +1,11 @@
 {
   "component": true,
   "usingComponents": {
-    <% if (useWrappedComponent) { %>
-      <% for (const component of components) {%>
-        <% if (component.isWrapped) {%>
-          "goji-<%= component.name %>": "<%= relativePathToBridge %>/<%= component.name %>",
-        <% } %>
-      <% }%>
-    <% } %>
+    <% for (const component of components) {%>
+      <% if (component.isWrapped) {%>
+        "goji-<%= component.name %>": "<%= relativePathToBridge %>/<%= component.name %>",
+      <% } %>
+    <% }%>
 
     "goji-subtree": "<%= relativePathToBridge %>/../subtree"
   }

--- a/packages/webpack-plugin/templates/item.json.ejs
+++ b/packages/webpack-plugin/templates/item.json.ejs
@@ -1,12 +1,10 @@
 {
   "usingComponents": {
-    <% if (useWrappedComponent) { %>
-      <% for (const component of components) {%>
-        <% if (component.isWrapped) {%>
-          "goji-<%= component.name %>": "<%= relativePathToBridge %>/components/<%= component.name %>",
-        <% } %>
-      <%[] }%>
-    <% }%>
+    <% for (const component of components) {%>
+      <% if (component.isWrapped) {%>
+        "goji-<%= component.name %>": "<%= relativePathToBridge %>/components/<%= component.name %>",
+      <% } %>
+    <%[] }%>
 
     <% if (useSubtree) { %>
     "goji-subtree": "<%= relativePathToBridge %>/subtree"

--- a/packages/webpack-plugin/templates/leaf-components.wxml.ejs
+++ b/packages/webpack-plugin/templates/leaf-components.wxml.ejs
@@ -1,8 +1,8 @@
 <block wx:if="{{false}}"></block>
 <% for (var component of components) {%>
   <block wx:elif="{{<% if (component.sid === undefined) {%>type === '<%= component.name %>'<%} else {%>sid === <%= component.sid %><%}%>}}">
-    <<%= useWrappedComponent && component.isWrapped ? 'goji-' : ''%><%= component.name %>
-      <% if (useWrappedComponent && component.isWrapped) { %>
+    <<%= component.isWrapped ? 'goji-' : ''%><%= component.name %>
+      <% if (component.isWrapped) { %>
         goji-id="{{id || -1}}"
         className="{{props.className}}"
         the-style="{{props.style || ''}}"
@@ -27,7 +27,7 @@
           <%= attribute.name %>="{{props.<%= attribute.value %>}}"
         <% } %>
       <% } %>
-      <% if (useWrappedComponent && component.isWrapped) { %>
+      <% if (component.isWrapped) { %>
         <%# wrapped components will handle event inside themselves %>
       <% } else { %>
         <% for (var event of component.events) {%>

--- a/packages/webpack-plugin/templates/subtree.json.ejs
+++ b/packages/webpack-plugin/templates/subtree.json.ejs
@@ -1,13 +1,11 @@
 {
   "component": true,
   "usingComponents": {
-    <% if (useWrappedComponent) { %>
-      <% for (const component of components) {%>
-        <% if (component.isWrapped) {%>
-          "goji-<%= component.name %>": "<%= relativePathToBridge %>/components/<%= component.name %>",
-        <% } %>
-      <% }%>
-    <% } %>
+    <% for (const component of components) {%>
+      <% if (component.isWrapped) {%>
+        "goji-<%= component.name %>": "<%= relativePathToBridge %>/components/<%= component.name %>",
+      <% } %>
+    <% }%>
 
     "goji-subtree": "<%= relativePathToBridge %>/subtree"
   }


### PR DESCRIPTION
This PR

1. Enable wrapped components support for all platforms.

We use `target` to check which components should be wrapped like `isWrapped: ['wechat', 'qq'].includes(target)` . So we can add wrapped component for any platform.

2. Fix the wrong `subtreeId` in non-wehcat-like platforms, like Alipay.

I use `process.env.GOJI_WRAPPED_COMPONENTS` replace the hard code list. The legacy list should be applied for Alipay, Baidu and etc.

The wrong `subtreeId` causes `getComponentInstance` pending forever.