### PR TITLE
Fix wrong non-WeChat platforms subtree id

### DIFF
--- a/packages/core/src/reconciler/__tests__/instance.test.tsx
+++ b/packages/core/src/reconciler/__tests__/instance.test.tsx
@@ -51,8 +51,10 @@ describe('ElementInstance', () => {
   });
 
   describe('getSubtreeId', () => {
-    // @ts-ignore
-    process.env.GOJI_WRAPPED_COMPONENTS = [];
+    beforeAll(() => {
+      // @ts-ignore
+      process.env.GOJI_WRAPPED_COMPONENTS = [];
+    });
     const view = () =>
       new ElementInstance('view', {}, [], new Container(new TestingAdaptorInstance()));
     const subtree = () =>
@@ -70,46 +72,76 @@ describe('ElementInstance', () => {
       }
     };
 
-    test('container works', () => {
-      let leaf: ElementInstance;
-      const elements = [view(), view(), (leaf = view())];
-      linkElements(elements);
-      expect(leaf.getSubtreeId()).toBe(undefined);
+    describe('wechat', () => {
+      beforeAll(() => {
+        process.env.GOJI_TARGET = 'wechat';
+      });
+
+      test('container works', () => {
+        let leaf: ElementInstance;
+        const elements = [view(), view(), (leaf = view())];
+        linkElements(elements);
+        expect(leaf.getSubtreeId()).toBe(undefined);
+      });
+
+      test('auto subtree works', () => {
+        let leaf: ElementInstance;
+        let sub: ElementInstance;
+        const elements = [view(), view(), view(), view(), (sub = view()), view(), (leaf = view())];
+        linkElements(elements);
+        expect(leaf.getSubtreeId()).toBe(sub.id);
+      });
+
+      test('manual subtree works', () => {
+        let leaf: ElementInstance;
+        let sub: ElementInstance;
+        const elements = [view(), view(), (sub = subtree()), view(), (leaf = view())];
+        linkElements(elements);
+        expect(leaf.getSubtreeId()).toBe(sub.id);
+      });
+
+      test('auto subtree inside manual subtree works', () => {
+        let leaf: ElementInstance;
+        let sub: ElementInstance;
+        const elements = [
+          view(),
+          view(),
+          subtree(),
+          view(),
+          view(),
+          view(),
+          view(),
+          (sub = view()),
+          view(),
+          (leaf = view()),
+        ];
+        linkElements(elements);
+        expect(leaf.getSubtreeId()).toBe(sub.id);
+      });
     });
 
-    test('auto subtree works', () => {
-      let leaf: ElementInstance;
-      let sub: ElementInstance;
-      const elements = [view(), view(), view(), view(), (sub = view()), view(), (leaf = view())];
-      linkElements(elements);
-      expect(leaf.getSubtreeId()).toBe(sub.id);
-    });
+    describe('non-wechat', () => {
+      beforeAll(() => {
+        process.env.GOJI_TARGET = 'baidu';
+      });
 
-    test('manual subtree works', () => {
-      let leaf: ElementInstance;
-      let sub: ElementInstance;
-      const elements = [view(), view(), (sub = subtree()), view(), (leaf = view())];
-      linkElements(elements);
-      expect(leaf.getSubtreeId()).toBe(sub.id);
-    });
-
-    test('auto subtree inside manual subtree works', () => {
-      let leaf: ElementInstance;
-      let sub: ElementInstance;
-      const elements = [
-        view(),
-        view(),
-        subtree(),
-        view(),
-        view(),
-        view(),
-        view(),
-        (sub = view()),
-        view(),
-        (leaf = view()),
-      ];
-      linkElements(elements);
-      expect(leaf.getSubtreeId()).toBe(sub.id);
+      test('subtree id should be always undefined', () => {
+        let leaf: ElementInstance;
+        const elements = [
+          view(),
+          view(),
+          subtree(),
+          view(),
+          view(),
+          view(),
+          view(),
+          view(),
+          view(),
+          (leaf = view()),
+        ];
+        linkElements(elements);
+        expect(leaf.getSubtreeId()).toBe(undefined);
+      });
     });
   });
 

--- a/packages/core/src/reconciler/instance.ts
+++ b/packages/core/src/reconciler/instance.ts
@@ -86,6 +86,11 @@ export class ElementInstance extends BaseInstance {
   public subtreeDepth?: number;
 
   public getSubtreeId(): number | undefined {
+    // FIXME: For now, only WeChat has subtree while other platforms render all elements in one page
+    // We should consider enabling non-WeChat subtree/wrapped components support
+    if (process.env.GOJI_TARGET !== 'wechat') {
+      return undefined;
+    }
     // wrapped component should return its wrapper as subtree id
     // `process.env.GOJI_WRAPPED_COMPONENTS` is generated from `@goji/webpack-plugin` to tell which
     // components are wrapped as custom components


### PR DESCRIPTION
For non-WeChat platforms, because they don't need subtree to pass by the recursive template issue the `subtree id` should always be `undefined`. In the previous codes, we forget to check the build target for them.

Wrong subtree id causes the `ref.getComponentsInstance` promise remains pending forever. Some features may fail, like `wx.createIntersectionObserver`.