### PR TITLE
Always use bundled dependencies

### DIFF
--- a/packages/cli/src/config/babel.config.ts
+++ b/packages/cli/src/config/babel.config.ts
@@ -22,20 +22,20 @@ const BABEL_MODULES = {
 module.exports = {
   presets: [
     [
-      '@babel/preset-env',
+      require.resolve('@babel/preset-env'),
       {
         modules: BABEL_MODULES[nodeEnv],
         targets: BABEL_PRESET_TARGETS[nodeEnv],
       },
     ],
-    '@babel/preset-typescript',
-    '@babel/preset-react',
+    require.resolve('@babel/preset-typescript'),
+    require.resolve('@babel/preset-react'),
   ],
   plugins: [
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-transform-runtime', { useESModules: true }],
-    ['@babel/plugin-proposal-optional-chaining', { loose: true }],
-    ['@babel/plugin-proposal-nullish-coalescing-operator', { loose: true }],
+    [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+    [require.resolve('@babel/plugin-transform-runtime'), { useESModules: true }],
+    [require.resolve('@babel/plugin-proposal-optional-chaining'), { loose: true }],
+    [require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'), { loose: true }],
   ],
   // https://github.com/webpack/webpack/issues/4039#issuecomment-419284940
   // https://babeljs.io/docs/en/options#sourcetype

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -112,7 +112,7 @@ export const getWebpackConfig = ({
             ...cacheLoaders,
             ...threadLoaders,
             {
-              loader: 'babel-loader',
+              loader: require.resolve('babel-loader'),
               options: babelConfig,
             },
             preprocessLoader('js', nodeEnv, target),
@@ -124,7 +124,7 @@ export const getWebpackConfig = ({
             MiniCssExtractPlugin.loader,
             ...cacheLoaders,
             {
-              loader: resolve.sync('css-loader', { basedir: __dirname }),
+              loader: require.resolve('css-loader'),
               options: {
                 modules: {
                   mode: 'local',
@@ -137,16 +137,14 @@ export const getWebpackConfig = ({
               },
             },
             {
-              loader: resolve.sync('@goji/webpack-plugin/dist/cjs/loaders/transform', {
-                basedir: __dirname,
-              }),
+              loader: require.resolve('@goji/webpack-plugin/dist/cjs/loaders/transform'),
               options: {
                 target,
                 type: 'wxss',
               },
             },
             {
-              loader: resolve.sync('postcss-loader', { basedir: __dirname }),
+              loader: require.resolve('postcss-loader'),
               options: {
                 config: {
                   path: __dirname,
@@ -158,7 +156,7 @@ export const getWebpackConfig = ({
             },
             preprocessLoader('js', nodeEnv, target),
             {
-              loader: resolve.sync('postcss-loader', { basedir: __dirname }),
+              loader: require.resolve('postcss-loader'),
               options: {
                 // eslint-disable-next-line global-require
                 plugins: [require('postcss-import')({})],
@@ -170,7 +168,7 @@ export const getWebpackConfig = ({
           test: /\.(png|jpg|jpeg|gif)$/,
           use: [
             {
-              loader: resolve.sync('file-loader', { basedir: __dirname }),
+              loader: require.resolve('file-loader'),
               options: {
                 name: 'assets/[name].[hash:6].[ext]',
               },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,8 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "react-is": "^16.13.1",
-    "react-reconciler": "^0.25.1"
+    "react-reconciler": "^0.25.1",
+    "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0"

--- a/packages/demo-todomvc/package.json
+++ b/packages/demo-todomvc/package.json
@@ -20,7 +20,8 @@
     "core-js": "^3.6.5",
     "react": "^16.13.1",
     "react-redux": "^7.2.1",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@goji/cli": "^0.7.6",

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -18,6 +18,7 @@
     "lodash": "^4.17.15",
     "pretty-format": "^26.0.1",
     "react-test-renderer": "^16.13.1",
+    "tslib": "^2.0.0",
     "wait-for-expect": "^3.0.2"
   },
   "jest": {

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -61,6 +61,7 @@
     "replace-ext": "^2.0.0",
     "resolve": "^1.17.0",
     "terser": "^4.7.0",
+    "tslib": "^2.0.0",
     "unified": "^9.0.0",
     "webpack-sources": "^1.4.3",
     "wx2swan": "^1.2.20"

--- a/packages/webpack-plugin/src/loaders/configFile.ts
+++ b/packages/webpack-plugin/src/loaders/configFile.ts
@@ -14,7 +14,9 @@ import {
 const loadAsset = async (context: webpack.loader.LoaderContext, assetPath: string) => {
   const source = await promisify(context.loadModule.bind(context))(
     // FIXME: should reuse `file-loader` rule from `webpack.config.js` ?
-    `!file-loader?esModule=false&name=assets/[name].[hash:6].[ext]&publicPath=/!${assetPath}`,
+    `!${require.resolve(
+      'file-loader',
+    )}?esModule=false&name=assets/[name].[hash:6].[ext]&publicPath=/!${assetPath}`,
   );
   return exec(source, assetPath, context.context);
 };


### PR DESCRIPTION
Since `@goji/cli` provides the whole build tools for a GojiJS project, it should always resolve dependencies from its `node_modules`.

# Why

To explain it let's consider such a situation that the GojiJS project `Foo` was generated by GojiJS CLI, and now we add a new dependency like `file-loader` to it.

```
└── foo
    └── node_modules
        ├── @goji
        │   └── cli
        │       └── node_modules
        │           └── file-loader v1
        └── file-loader v2
```

In this case, `@goji/cli` should always `file-loader v1` rather than `v2` because mismatch dependencies may not work well.

But in Babel and WebPack, the string value like `file-loader` means they would resolve the module from `process.env.PWD`. This result in the wrong module resolved.

# How

I use `require.resolve` to return the full path of Babel preset/plugins and WebPack loaders and resolved the issue.

To test it, I created a GojiJS project and removed `@goji/cli` from its dependencies, then run `../goji-js/node_modules/.bin/goji start` in it. 

> I'm not sure how to implement this test case in CI so I just run it locally.