### PR TITLE
drop node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['10', '12', '14']
+        node-version: ['12', '14']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
because this isn't a server side process we do not need to provide a long tail version support