### PR TITLE
Fix wrong result of `new Array` due to webpack shim plugin

### DIFF
--- a/packages/webpack-plugin/src/plugins/shim/patches/__tests__/array.test.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/__tests__/array.test.ts
@@ -1,0 +1,79 @@
+describe('patch `Array`', () => {
+  let PatchedArray: typeof Array;
+
+  beforeAll(() => {
+    // eslint-disable-next-line global-require
+    PatchedArray = require('../array');
+  });
+
+  afterAll(() => {
+    delete process.env.GOJI_TARGET;
+  });
+
+  test('new Array()', () => {
+    const array = new PatchedArray();
+    expect(array.length).toBe(0);
+    expect(Array.from(array)).toEqual([]);
+  });
+
+  test('Array()', () => {
+    const array = PatchedArray();
+    expect(array.length).toBe(0);
+    expect(Array.from(array)).toEqual([]);
+  });
+
+  test('new Array(len)', () => {
+    const array = new PatchedArray(3);
+    expect(array.length).toBe(3);
+    expect(Array.from(array)).toEqual([undefined, undefined, undefined]);
+  });
+
+  test('new Array(T1, T2)', () => {
+    const array = new PatchedArray<number | string>(3, 'a');
+    expect(array.length).toBe(2);
+    expect(Array.from(array)).toEqual([3, 'a']);
+  });
+
+  it('instanceof', () => {
+    const array = new PatchedArray();
+    expect(array).toBeInstanceOf(PatchedArray);
+
+    const arrayNative = [];
+    expect(arrayNative).toBeInstanceOf(PatchedArray);
+  });
+
+  it('prototype', () => {
+    const array = new PatchedArray();
+    expect(Object.getPrototypeOf(array)).toBe(PatchedArray.prototype);
+  });
+
+  // FIXME: i didn't find a way to hack this test case
+  it.skip('prototype native', () => {
+    const arrayNative = () => {};
+    expect(Object.getPrototypeOf(arrayNative)).toBe(PatchedArray.prototype);
+  });
+
+  it('patch prototype method', () => {
+    // @ts-ignore
+    PatchedArray.prototype.myMethod = function myMethod() {
+      return `${this.length} test`;
+    };
+    const array = new PatchedArray(3);
+    // @ts-ignore
+    expect(typeof array.myMethod).toBe('function');
+    // @ts-ignore
+    expect(array.myMethod()).toBe('3 test');
+  });
+
+  it('constructor', () => {
+    const array = new PatchedArray();
+    expect(array.constructor).toBe(PatchedArray);
+  });
+
+  // FIXME: we can't hack native constructor,
+  // wechat js context may compare it directly to origianl constructor
+  it.skip('native constructor', () => {
+    const arrayNative = [];
+    expect(arrayNative.constructor).toBe(PatchedArray);
+  });
+});


### PR DESCRIPTION
# TL;DR,

`new Array()` and `new Array(a, b, c)` doesn't work in GojiJS because of an internal issue in `WebpackShimPlugin`.

# Root cause

The `WebpackShimPlugin` patches several global variables to fix the prototype frozen issue on WeChat. These variables includs `Array` / `String` / `Promise and etc.

But the implement of `PatchedArray` has a certain issue. It only support the `new Array(length)` usage and others may fails.

| source            | expect          | in fact         | result |
| ----------------- | --------------- | --------------- | ------ |
| new Array()       | []              | [undefined]     | ✘      |
| new Array(3)      | [undefined * 3] | [undefined * 3] | ✔      |
| new Array(3, 'a') | [3, 'a']        | [undefined * 3] | ✘      |

# Impact

Of course, this bug might affect 3rd libraries and business codes. I believe https://github.com/airbnb/goji-js/issues/39 is related to this issue.

Fortunately, in most of cases developers prefer to use *more standard* usage `new Array(length)`. I scan sentence `new Array` in the common chunk of our Airbnb Mini Program output, and all of these 21 results can work as expect.

So I guess only few codes would be affected by this issue.

