### PR TITLE
Deprecate onLongTap and always use onLongPress

### DIFF
--- a/packages/core/src/components/factoryComponents.ts
+++ b/packages/core/src/components/factoryComponents.ts
@@ -13,7 +13,6 @@ interface BaseProps {
   onTouchend?: (e: any) => void;
   onTap?: (e: any) => void;
   onLongpress?: (e: any) => void;
-  onLongtap?: (e: any) => void;
   onTransitionend?: (e: any) => void;
   onAnimationstart?: (e: any) => void;
   onAnimationiteration?: (e: any) => void;

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,6 +1,15 @@
 import camelCase from 'lodash/camelCase';
 import { ElementInstance } from './reconciler/instance';
 
+// Alipay doesn't support `longpress` so we have to use `longtap` in bridge templates
+// and then we should change the `e.type` to make sure correct callback to be called.
+// For more details see https://github.com/airbnb/goji-js/pull/48
+const processingEventBeforeDispatch = (e: any) => {
+  if (process.env.GOJI_TARGET === 'alipay' && e.type === 'longTap') {
+    e.type = 'longPress';
+  }
+};
+
 export class GojiEvent {
   private instanceMap = new Map<number, ElementInstance>();
 
@@ -16,6 +25,7 @@ export class GojiEvent {
   }
 
   public triggerEvent(e: any) {
+    processingEventBeforeDispatch(e);
     const { target, currentTarget, timeStamp } = e;
 
     const id = currentTarget.dataset.gojiId;

--- a/packages/webpack-plugin/src/constants/components.ts
+++ b/packages/webpack-plugin/src/constants/components.ts
@@ -15,7 +15,7 @@ const sortComponents = component => {
   });
 };
 
-const addCommonEvents = (components: ComponentDesc[]) => {
+const addCommonEvents = (target: GojiTarget, components: ComponentDesc[]) => {
   for (const component of components) {
     component.events.push(
       'touch-start',
@@ -23,8 +23,9 @@ const addCommonEvents = (components: ComponentDesc[]) => {
       'touch-cancel',
       'touch-end',
       'tap',
-      'long-press',
-      'long-tap',
+      // Alipay doesn't support `longpress` so we have to use `longtap` in bridge templates.
+      // For more details see https://github.com/airbnb/goji-js/pull/48
+      target === 'alipay' ? 'long-tap' : 'long-press',
       'transition-end',
       'animation-start',
       'animation-iteration',
@@ -63,7 +64,7 @@ export type ComponentDesc = {
 // docs: https://developers.weixin.qq.com/miniprogram/en/dev/component/
 export const getBuiltInComponents = (target: GojiTarget): ComponentDesc[] =>
   sortComponents(
-    addCommonEvents([
+    addCommonEvents(target, [
       // View Container
       {
         name: 'movable-view',


### PR DESCRIPTION
# Summary

There are two event types, `long tap` and `long press`, to watch the long press interactive action. But they have inconsistent behaviors on different platforms.

This PR tries to deprecate `long tap` event and forces using `long press` instead.

# Why

1. `long tap` is useless and deprecated. For example, WeChat official document says *手指触摸后，超过350ms再离开（推荐使用longpress事件代替）*

2. Inconsistent behaviors make developers confused.

| Platform              | WeChat                | QQ                    | Baidu              | Alipay           | Toutiao               |
| --------------------- | --------------------- | --------------------- | ------------------ | ---------------- | --------------------- |
| longpress support     | ✓                     | ✓                     | ✓                  | ✘                | ✓                     |
| longtap support       | ✓                     | ✓                     | ✓                  | ✓(500ms)         | ✓                     |
| tap+longpress         | only longpress        | only longpress        | only longpress     | ✘                | only longpress        |
| tap+longtap           | tap and longtap       | tap and longtap       | **only longtap**   | **only longtap** | **only longtap**      |
| tap+longpress+longtap | longpress and longtap | longpress and longtap | **only longpress** | ✘                | longpress and longtap |

We found,

* Alipay only support `long tap` which in fact works as same way as `long press` on WeChat.

* Many platforms doesn't support `tap+longtap` well.

* I believe `tap+longpress` is the most reasonable usage.

3. In current version of GojiJS, developers need to check environment variable to detect which event name should be used, like this.

```tsx
const onLongPressKey = process.env.GOJI_TARGET === 'alipay' ? 'onLongTap' : 'onLongPress';
const Comp = () => <View {...{ [onLongPressKey]: 1 }} />;
```

# How

This PR unifies the usage of two events. `onLongPress` is the only support way in GojiJS.

When Goji CLI rendering bridge files ( `_goji` folder ), it uses `<view onLongTap="e">` on Alipay and `<view bindlongpress="e">` on other platforms. This make sure code compatible with every platforms.

# Test Plan

I tested `onTap` and `onLongPress` on these platforms.

WeChat:

![RPReplay_Final1607185811](https://user-images.githubusercontent.com/1812118/101256939-82719c00-375a-11eb-89ac-a71feec744d8.gif)

Alipay:

![RPReplay_Final1607185898](https://user-images.githubusercontent.com/1812118/101256942-86052300-375a-11eb-995f-b9214e1f4de0.gif)

Baidu:

![RPReplay_Final1607185980](https://user-images.githubusercontent.com/1812118/101257495-b51b9480-375a-11eb-9969-535d4825b182.gif)
