### PR TITLE
Extract faster-babel-loader-for-macro to speed up build time

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,6 +71,7 @@
     "@types/yargs": "^15.0.5"
   },
   "peerDependencies": {
-    "@goji/core": "*"
+    "@goji/core": "*",
+    "source-map": "*"
   }
 }

--- a/packages/cli/src/config/fasterBabelLoaderForMacro.ts
+++ b/packages/cli/src/config/fasterBabelLoaderForMacro.ts
@@ -1,0 +1,28 @@
+import { loader } from 'webpack';
+import babelLoader from 'babel-loader';
+import { RawSourceMap } from 'source-map';
+
+// inspired from https://github.com/kentcdodds/babel-plugin-macros/blob/18d79d3ac3c2975565e7897d2233cf498f15ffb5/src/index.js#L5
+const macrosRegex = /[./]macro(\.c?js)?['"]/;
+const testMacrosRegex = v => macrosRegex.test(v);
+
+/**
+ * this loader is designed to only support `babel-plugin-macros`, don't use any other plugins
+ */
+module.exports = function GojiTransformLoader(
+  this: loader.LoaderContext,
+  source: string | Buffer,
+  inputSourceMap: RawSourceMap,
+) {
+  const callback = this.async();
+  if (this.cacheable) {
+    this.cacheable();
+  }
+
+  if (testMacrosRegex(source.toString())) {
+    babelLoader.call(this, source, inputSourceMap);
+    return;
+  }
+
+  callback!(null, source);
+};

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -112,7 +112,8 @@ export const getWebpackConfig = ({
           use: [
             // support `@goji/macro`
             {
-              loader: require.resolve('babel-loader'),
+              // loader: require.resolve('babel-loader'),
+              loader: require.resolve('./fasterBabelLoaderForMacro'),
               options: {
                 plugins: [[require.resolve('babel-plugin-macros'), { gojiMacro: { target } }]],
               },


### PR DESCRIPTION
To support `@goji/macro` feature, the Webpack always create a new instance of `babel` in each call of `babel-loader`.
But in fact, we could only parse files that include `import from macro` statement. So I create a `faster-babel-loader-for-macro` that check whether the file match [`/[./]macro(\.c?js)?$/`](https://github.com/kentcdodds/babel-plugin-macros/blob/18d79d3ac3c2975565e7897d2233cf498f15ffb5/src/index.js#L5) regex before parse them.

```tsx
import { registerPluginComponent } from '@goji/macro'; // should parse this file
```

This PR reduced 25% Webpack bundling time.

|     | Before | After |
| --- | ------ | ----- |
| 1   | 13.3   | 10.26 |
| 2   | 12.65  | 9.63  |
| 3   | 12.82  | 9.5   |
| 4   | 12.76  | 9.21  |
| 5   | 12.67  | 9.52  |
| Avg | 12.84  | 9.624 |
