### PR TITLE
Fix Linaria `cacheDirectory`

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -130,7 +130,11 @@ export const getWebpackConfig = ({
                 configFile: require.resolve('./linaria.config'),
                 sourceMap: true,
                 // Linaria defaults to use `.linaria-cache` folder rather than standard `node_modules/.cache`
-                cacheDirectory: findCacheDir({ name: 'linaria', cwd: basedir }),
+                // also we should use different folders based on `nodeEnv` and `target` to prevent wrong cache result
+                cacheDirectory: findCacheDir({
+                  name: `linaria-${nodeEnv}-${target}`,
+                  cwd: basedir,
+                }),
                 babelOptions: {
                   // always use internal babel.config.js file
                   configFile: require.resolve('./babel.config'),


### PR DESCRIPTION
In different `nodeEnv` and `target`, the Linaria should use different `cacheDirectory`.

This is an example.

```css
/* nodeEnv === 'development' */
.logo_l7007{margin-top:180rpx;color:#ff385c;}
```

```css
/* nodeEnv === 'production' */
.l7007{margin-top:180rpx;color:#ff385c;}
```