### PR TITLE
Fix symlink support in configFile loader

### DIFF
--- a/packages/webpack-plugin/src/plugins/entry.ts
+++ b/packages/webpack-plugin/src/plugins/entry.ts
@@ -49,12 +49,14 @@ export class GojiEntryWebpackPlugin extends GojiBasedWebpackPlugin {
     const pathEntries = readPathsFromAppConfig(appConfig);
 
     // add app & pages
-    for (const pathEntry of [appEntry, ...pathEntries]) {
-      const request = loaderUtils.urlToRequest(pathEntry);
+    for (const theEntry of [appEntry, ...pathEntries]) {
+      const request = loaderUtils.urlToRequest(theEntry);
       new webpack.SingleEntryPlugin(
         context,
-        `${require.resolve('../loaders/configFile')}?target=${this.options.target}!${request}`,
-        pathEntry,
+        `${require.resolve('../loaders/configFile')}?target=${
+          this.options.target
+        }&entry=${theEntry}!${request}`,
+        theEntry,
       ).apply(compiler);
     }
     // save for other plugins


### PR DESCRIPTION
# Reproduce

1. Create a new folder `test` anywhere outside the `goji-js` repo.
2. Link the `goji-js/packages/demo-todomvc` into `test` folder.
3. Run yarn build in `test/demo-todomvc`.
4. Useless files are generated in the `src` folder.

# Root cause

Webpack always resolve the symlink in the `this.request` of a loader.

For example, we use `/path/to/configFile?target=wechat!./pages/index` to process the `pages/index.config.ts` file. Webpack always convert the request to `/path/to/configFile?target=wechat!/path/to/test/src/pages/index` rather than keeping the original request. So it is hard to calculate the correct entry path, which is the relative path from request to root context.

# Fix

In this PR, I add a new loader's param to passthrough the entry path from the plugin to loader.