### PR TITLE
Change babel.config.js to fix iOS white screen issue

### DIFF
--- a/packages/cli/src/config/babel.config.ts
+++ b/packages/cli/src/config/babel.config.ts
@@ -26,6 +26,8 @@ module.exports = {
       {
         modules: BABEL_MODULES[nodeEnv],
         targets: BABEL_PRESET_TARGETS[nodeEnv],
+        useBuiltIns: 'entry',
+        corejs: 3,
       },
     ],
     require.resolve('@babel/preset-typescript'),


### PR DESCRIPTION
# Reproduction

> You can try in this demo: `packages/demo-todomvc`

1. Enable WeChat live plugin by adding these lines into `app.json`.

```json
"plugins": {
  "live-player-plugin": {
    "version": "1.2.0",
    "provider": "wx2b03c6e691cd7370"
  }
}
```

2. Change the test app id to a real one which has the permission of using [WeChat Live Plugin](https://developers.weixin.qq.com/miniprogram/dev/framework/liveplayer/live-player-plugin.html).

2. Run `yarn build`.

3. Preview the `dist/wechat` folder by WeChat Dev Tool in a iOS 11 device.

# Cause

By default GojiJS use `import 'core-js/stable';` as polyfill. It contains a list of ES features.

One of them is `core-js/modules/es.json.stringify.js`. This feature fails to run on legacy iOS devices, like iOS 11/12, with raising a `TypeError` and then cause a white screen issue.

![WechatIMG27](https://user-images.githubusercontent.com/1812118/111284163-d9044580-867a-11eb-8109-e8f1fceabc6e.png)

This might not be the root cause of the issue, but currently we can disable this feature to fix the white screen issue.

# Fix

The `corejs: 3` option let Babel filter out useless features, including `core-js/modules/es.json.stringify.js`.

Also it reduced 5kb bundle size ( from 309kb to 304kn in `demo-todomvc`.