### PR TITLE
Enable `id` for all elements

### DIFF
--- a/packages/core/src/components/componentsTypes.ts
+++ b/packages/core/src/components/componentsTypes.ts
@@ -5,6 +5,7 @@ import { SetDifference } from 'utility-types';
 
 interface BaseProps {
   testID?: string;
+  id?: string;
   className?: string;
   style?: CSSProperties;
   onTouchstart?: (e: any) => void;
@@ -697,7 +698,6 @@ interface MapSetting {
 }
 
 export interface MapProps extends BaseProps {
-  id?: string;
   longitude: number;
   latitude: number;
   scale?: number;

--- a/packages/webpack-plugin/templates/components.wxml.ejs
+++ b/packages/webpack-plugin/templates/components.wxml.ejs
@@ -9,25 +9,25 @@
   <%# FIXME: how to handle more depth of `text` ? %>
   <%# FIXME: refactor these lines for better readable %>
   <% if (useFlattenText) { %>
-    <text wx:elif="{{type === 'text'}}" data-goji-id="{{id || -1}}" class="{{props.className}}" style="{{props.style || ''}}" selectable="{{props.selectable}}" space="{{props.space}}" decode="{{props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
+    <text wx:elif="{{type === 'text'}}" data-goji-id="{{id || -1}}" id="{{props.id}}" class="{{props.className}}" style="{{props.style || ''}}" selectable="{{props.selectable}}" space="{{props.space}}" decode="{{props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
       <block wx:for="{{c}}" wx:key="id">
         <block wx:if="{{item.type === 'GOJI_TYPE_TEXT'}}">{{item.text}}</block>
-        <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
+        <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" id="{{props.id}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
           <block wx:for="{{item.c}}" wx:key="id">
             <block wx:if="{{item.type === 'GOJI_TYPE_TEXT'}}">{{item.text}}</block>
-            <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
+            <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" id="{{props.id}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
               <block wx:for="{{item.c}}" wx:key="id">
                 <block wx:if="{{item.type === 'GOJI_TYPE_TEXT'}}">{{item.text}}</block>
-                <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
+                <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" id="{{props.id}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
                   <block wx:for="{{item.c}}" wx:key="id">
                     <block wx:if="{{item.type === 'GOJI_TYPE_TEXT'}}">{{item.text}}</block>
-                    <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
+                    <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" id="{{props.id}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
                       <block wx:for="{{item.c}}" wx:key="id">
                         <block wx:if="{{item.type === 'GOJI_TYPE_TEXT'}}">{{item.text}}</block>
-                        <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
+                        <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" id="{{props.id}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e">
                           <block wx:for="{{item.c}}" wx:key="id">
                             <block wx:if="{{item.type === 'GOJI_TYPE_TEXT'}}">{{item.text}}</block>
-                            <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e"></text>
+                            <text wx:elif="item.type === 'text'" data-goji-id="{{item.id || -1}}" id="{{props.id}}" class="{{item.props.className}}" style="{{item.props.style || ''}}" selectable="{{item.props.selectable}}" space="{{item.props.space}}" decode="{{item.props.decode}}" bindtouchstart="e" bindtouchmove="e" bindtouchcancel="e" bindtouchend="e" bindtap="e" bindlongpress="e" bindlongtap="e" bindtransitionend="e" bindanimationstart="e" bindanimationiteration="e" bindanimationend="e" bindtouchforcechange="e"></text>
                           </block>
                         </text>
                       </block>
@@ -47,6 +47,7 @@
     <block wx:elif="{{type === 'swiper'}}">
       <swiper
         data-goji-id="{{id || -1}}"
+        id="{{props.id}}"
         class="{{props.className}}"
         style="{{props.style || ''}}"
         indicator-dots="{{props.indicatorDots}}"
@@ -97,10 +98,12 @@
         nodes="{{c}}"
         goji-id="{{id || -1}}"
         class-name="{{props.className}}"
+        the-id="{{props.id}}"
         the-style="{{props.style || ''}}"
       <% } else { %>
         data-goji-id="{{id || -1}}"
         class="{{props.className}}"
+        id="{{props.id}}"
         style="{{props.style || ''}}"
       <% } %>
         <% for (var attribute of component.attributes) {%>

--- a/packages/webpack-plugin/templates/components/input.js.ejs
+++ b/packages/webpack-plugin/templates/components/input.js.ejs
@@ -18,6 +18,9 @@ Component({
         }
       },
     },
+    theId: {
+      type: String,
+    },
     className: {
       type: String,
     },

--- a/packages/webpack-plugin/templates/components/input.wxml.ejs
+++ b/packages/webpack-plugin/templates/components/input.wxml.ejs
@@ -1,4 +1,5 @@
 <input
+  id="{{theId}}"
   class="{{className}}"
   style="{{theStyle}}"
   data-goji-id="{{gojiId}}"

--- a/packages/webpack-plugin/templates/components/scroll-view.js.ejs
+++ b/packages/webpack-plugin/templates/components/scroll-view.js.ejs
@@ -11,6 +11,9 @@ Component({
     nodes: {
       type: Object,
     },
+    theId: {
+      type: String,
+    },
     className: {
       type: String,
     },

--- a/packages/webpack-plugin/templates/components/scroll-view.wxml.ejs
+++ b/packages/webpack-plugin/templates/components/scroll-view.wxml.ejs
@@ -1,4 +1,5 @@
 <scroll-view
+  id="{{theId}}"
   class="{{className}}"
   style="{{theStyle}}"
   data-goji-id="{{gojiId}}"

--- a/packages/webpack-plugin/templates/components/swiper-item.wxml.ejs
+++ b/packages/webpack-plugin/templates/components/swiper-item.wxml.ejs
@@ -1,5 +1,7 @@
 <swiper-item
+  id="{{id}}"
   class="{{className}}"
+  style="{{style}}"
   data-goji-id="{{gojiId}}"
   item-id="{{itemId}}"
 >

--- a/packages/webpack-plugin/templates/components/swiper.js.ejs
+++ b/packages/webpack-plugin/templates/components/swiper.js.ejs
@@ -9,6 +9,9 @@ Component({
     nodes: {
       type: Object,
     },
+    theId: {
+      type: String,
+    },
     className: {
       type: String,
     },

--- a/packages/webpack-plugin/templates/components/swiper.wxml.ejs
+++ b/packages/webpack-plugin/templates/components/swiper.wxml.ejs
@@ -1,4 +1,5 @@
 <swiper
+  id="{{theId}}"
   class="{{className}}"
   style="{{theStyle}}"
   data-goji-id="{{gojiId}}"

--- a/packages/webpack-plugin/templates/components/textarea.js.ejs
+++ b/packages/webpack-plugin/templates/components/textarea.js.ejs
@@ -18,6 +18,9 @@ Component({
         }
       },
     },
+    theId: {
+      type: String,
+    },
     className: {
       type: String,
     },
@@ -101,4 +104,3 @@ Component({
     },
   },
 });
-  

--- a/packages/webpack-plugin/templates/components/textarea.wxml.ejs
+++ b/packages/webpack-plugin/templates/components/textarea.wxml.ejs
@@ -1,4 +1,5 @@
 <textarea
+  id="{{theId}}"
   class="{{className}}"
   style="{{theStyle}}"
   data-goji-id="{{gojiId}}"

--- a/packages/webpack-plugin/templates/leaf-components.wxml.ejs
+++ b/packages/webpack-plugin/templates/leaf-components.wxml.ejs
@@ -5,16 +5,13 @@
       <% if (component.isWrapped) { %>
         goji-id="{{id || -1}}"
         className="{{props.className}}"
+        the-id="{{props.id}}"
         the-style="{{props.style || ''}}"
       <% } else { %>
         data-goji-id="{{id || -1}}"
         class="{{props.className}}"
+        id="{{props.id}}"
         style="{{props.style || ''}}"
-      <% } %>
-      <%# FIXME: for performance reason we haven't enable `id` for all components %>
-      <%# only several components which required by `wx.` API are patched %>
-      <% if (component.name === 'map') { %>
-        the-id="{{props.id}}"
       <% } %>
       <% for (var attribute of component.attributes) {%>
         <% if (typeof attribute.fallback !== "undefined") {%>


### PR DESCRIPTION
The PR add the `id` attribute for all elements.

There are some use cases of `id`:

1. [wx.pageScrollTo](https://developers.weixin.qq.com/miniprogram/dev/api/ui/scroll/wx.pageScrollTo.html) support id selector.
2. [wx.createMapContext](https://developers.weixin.qq.com/miniprogram/dev/api/media/map/wx.createMapContext.html) need map has a `id`.
3. CSS can use `id` selector.

This PR increase 1.4kb bundle size in our Mini Program, which should be acceptable.