### PR TITLE
Stop watching `node_modules/.cache` folder in dev mode

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -96,6 +96,9 @@ export const getWebpackConfig = ({
     },
     watchOptions: {
       poll: GojiWebpackPlugin.getPoll(),
+      // should not watch cache file, for example Linaria use `node_modules/.cache/` to store temporary
+      // .css files that cause Webpack re-compile twice for a single change
+      ignored: [/node_modules\/\.cache/],
     },
     stats: getStats(),
     performance: {


### PR DESCRIPTION
Linaria use `node_modules/.cache/` to store temporary .css files that cause Webpack re-compile twice for a single change.

So this PR add an `ignored: [/node_modules\/\.cache/]` option to step watch cache folders.