### PR TITLE
Revert "stop watching `node_modules/.cache` folder in dev mode"

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -98,9 +98,6 @@ export const getWebpackConfig = ({
     },
     watchOptions: {
       poll: GojiWebpackPlugin.getPoll(),
-      // should not watch cache file, for example Linaria use `node_modules/.cache/` to store temporary
-      // .css files that cause Webpack re-compile twice for a single change
-      ignored: [/node_modules\/\.cache/],
     },
     stats: getStats(),
     performance: {


### PR DESCRIPTION
Revert https://github.com/airbnb/goji-js/pull/73 beacuse Linaria fails to refresh in dev mode.