### PR TITLE
Refactor container code by introducing a new virtual root element

### DIFF
--- a/packages/core/src/adaptor/__tests__/__snapshots__/wechat.test.tsx.snap
+++ b/packages/core/src/adaptor/__tests__/__snapshots__/wechat.test.tsx.snap
@@ -5,14 +5,14 @@ Object {
   "c": Array [
     Object {
       "c": Array [],
-      "id": 1,
+      "id": 2,
       "props": Object {},
       "sid": 0,
       "type": "view",
     },
   ],
-  "id": -1,
+  "id": 1,
   "props": Object {},
-  "type": "goji_root",
+  "type": "GOJI_VIRTUAL_ROOT",
 }
 `;

--- a/packages/core/src/adaptor/common.ts
+++ b/packages/core/src/adaptor/common.ts
@@ -6,10 +6,6 @@ export abstract class Adaptor {
 
 export abstract class AdaptorInstance {
   public abstract updateData(data: any, callback: () => void, renderId: string): void;
-
-  public abstract registerEventHandling(handlerKey: string, handler: Function): void;
-
-  public abstract unregisterEventHandler(handlerKey: string): void;
 }
 
 export type AdaptorType = 'page' | 'component' | 'exportComponent';

--- a/packages/core/src/adaptor/wechat.tsx
+++ b/packages/core/src/adaptor/wechat.tsx
@@ -66,14 +66,6 @@ export class WechatAdaptorInstance extends AdaptorInstance {
     }
     this.instance.setData(data, callback);
   }
-
-  public registerEventHandling(handlerKey: string, handler: Function) {
-    this.instance[handlerKey] = handler;
-  }
-
-  public unregisterEventHandler(handlerKey: string) {
-    delete this.instance[handlerKey];
-  }
 }
 
 const ExportComponentWrapper = ({

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,4 @@
+export const GOJI_VIRTUAL_ROOT = 'GOJI_VIRTUAL_ROOT';
 export const TYPE_TEXT = 'GOJI_TYPE_TEXT';
 export const TYPE_SUBTREE = 'GOJI_TYPE_SUBTREE';
 

--- a/packages/core/src/reconciler/hostConfig.ts
+++ b/packages/core/src/reconciler/hostConfig.ts
@@ -113,7 +113,7 @@ export const hostConfig: GojiHostConfig<
   },
 
   insertInContainerBefore(container, child, beforeChild) {
-    container.insertBefore(child, beforeChild);
+    container.virtualRootElement.insertBefore(child, beforeChild);
   },
 
   finalizeInitialChildren: () => {
@@ -121,7 +121,7 @@ export const hostConfig: GojiHostConfig<
   },
 
   appendChildToContainer(container, child) {
-    container.appendChild(child);
+    container.virtualRootElement.appendChild(child);
   },
 
   removeChild(parentInstance, child) {
@@ -131,7 +131,7 @@ export const hostConfig: GojiHostConfig<
 
   removeChildFromContainer(container, child) {
     child.unregisterEventHandler();
-    container.removeChild(child);
+    container.virtualRootElement.removeChild(child);
   },
 
   resetTextContent() {

--- a/packages/core/src/reconciler/instance.ts
+++ b/packages/core/src/reconciler/instance.ts
@@ -179,7 +179,12 @@ export class ElementInstance extends BaseInstance {
     }
 
     if (tag === UpdateType.CREATED) {
-      updates[path] = node;
+      if (path) {
+        updates[path] = node;
+      } else {
+        // always use fully update for root element
+        Object.assign(updates, node);
+      }
     }
 
     return [node, updates];


### PR DESCRIPTION
This PR refactor internal data structure of `@goji/core`. No exported API is changed.

Before:
`Container` is a superset of `ElementInstance`. Both of them has similar methods like `appendChild`/`insertBefore`.
Many codes are duplicated between these two classes.

After:
Introduce a new virtual root element called  `GOJI_VIRTUAL_ROOT`. 

```tsx
class Container {
  public virtualRootElement = new ElementInstance(GOJI_VIRTUAL_ROOT, {}, [], this);
}
```

It contains both root dom and portal doms and looks like this:

```html
<GOJI_VIRTUAL_ROOT>
  <view>the root dom</view>
  <view>the portal dom 1</view>
  <view>the portal dom 2</view>
  <view>the portal dom 3</view>
  ...
</GOJI_VIRTUAL_ROOT>
```

But, we will never render such a `GOJI_VIRTUAL_ROOT` element into pages. We only render its children elements. So we don't have to change bridge files in this PR.

```html
<import src="../../_goji/components0.wxml"/>
<block wx:for="{{c}}" wx:key="id">
    <template is="$$GOJI_COMPONENT0" data="{{ ...item }}" />
</block>
```