### PR TITLE
use node 16, deprecate node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['10', '12', '14']
+        node-version: ['12', '14', '16']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
- https://nodejs.medium.com/node-js-16-available-now-7f5099a97e70
- node 10 LTS ends end of April