### PR TITLE
Disable <map>'s setting usage temporary

### DIFF
--- a/packages/webpack-plugin/src/constants/components.ts
+++ b/packages/webpack-plugin/src/constants/components.ts
@@ -1635,10 +1635,12 @@ export const getBuiltInComponents = (target: GojiTarget): ComponentDesc[] =>
             required: false,
             type: 'Boolean',
           },
-          setting: {
-            required: false,
-            type: 'Object',
-          },
+          // Disable <map>'s setting usage temporary
+          // for more details see https://github.com/airbnb/goji-js/pull/103
+          // setting: {
+          //   required: false,
+          //   type: 'Object',
+          // },
         },
         events: [
           'markertap',

--- a/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/wrapped.js.test.tsx.snap
+++ b/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/wrapped.js.test.tsx.snap
@@ -231,9 +231,6 @@ exports[`wrapped.js snapshot works: map 1`] = `
     enableBuilding: {
       type: Boolean,
     },
-    setting: {
-      type: Object,
-    },
   },
   lifetimes: {
     attached() {


### PR DESCRIPTION
# Why

These bad cases can reproduce the issue that empty `setting` field cause the map fails to render on iOS devices.

GojiJS ( v0.11.0 ):

```tsx
import React from 'react';
import { render, Map } from '@goji/core';

render(<Map latitude={31.2253} longitude={121.45928} />);
```

Native WeChat Mini Program:

https://developers.weixin.qq.com/s/0e9NPsmd7fss

# How

I thought several solutions, but non of them are 100% perfect to solve the issue.

1. Set default value for `setting`, including these ways:

* Add `value: {}` for `properties` field in `map.js`
* Add `setting="{{setting || defauleValue}}"` in `map.wxml`, but literal `{}` doesn't work in wxml.

2. Don't render `setting="{{setting}}"` field in `map.wxml` at all.

By now, I prefer to disable the usage of `setting` property to unblock white screen issue. And I will fix this bug later.

# Ref

https://developers.weixin.qq.com/miniprogram/dev/component/map.html#setting