### PR TITLE
Fix create-goji-app cli and add test cases

### DIFF
--- a/packages/create-goji-app/src/__tests__/index.test.ts
+++ b/packages/create-goji-app/src/__tests__/index.test.ts
@@ -1,0 +1,33 @@
+import { promisify } from 'util';
+import { exec } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+describe('create-goji-app', () => {
+  jest.setTimeout(5 * 60 * 1000);
+
+  it('create project', async () => {
+    // prepare
+    const binPath = require.resolve('../../bin/create-goji-app');
+    const workDir = '/tmp/.create-goji-app';
+    await fs.promises.rmdir(workDir, { recursive: true });
+    await fs.promises.mkdir(workDir, { recursive: true });
+    const projectName = 'my-goji-app';
+    const projectDir = path.join(workDir, projectName);
+
+    // create project
+    await promisify(exec)(`${binPath} ${projectName}`, { cwd: workDir });
+    expect(await fs.promises.stat(path.join(projectDir, 'package.json'))).toBeTruthy();
+    /* eslint-disable global-require, import/no-dynamic-require */
+    expect(require(path.join(projectDir, 'package.json')).dependencies['@goji/core']).toBe(
+      `^${require('../../package.json').version}`,
+    );
+    /* eslint-enable global-require, import/no-dynamic-require */
+
+    // run `yarn install`
+    await promisify(exec)('yarn', { cwd: projectDir });
+
+    // run `yarn build`
+    await promisify(exec)('yarn build', { cwd: projectDir });
+  });
+});

--- a/packages/create-goji-app/src/generator.ts
+++ b/packages/create-goji-app/src/generator.ts
@@ -21,6 +21,8 @@ export const generateProject = async (projectName, sourcePath: string, destPath:
     const destFile = path.join(destPath, relativePath);
     await renderTemplate(sourceFile, destFile, {
       projectName,
+      // eslint-disable-next-line global-require, import/no-unresolved
+      version: require('../../package.json').version,
     });
   }
 };

--- a/packages/create-goji-app/templates/package.json
+++ b/packages/create-goji-app/templates/package.json
@@ -12,13 +12,19 @@
     "build": "goji build"
   },
   "dependencies": {
-    "@goji/core": "^0.7.6",
+    "@goji/core": "^<%= version %>",
     "classnames": "^2.2.6",
     "core-js": "^3.6.5",
     "react": "^16.13.1"
   },
   "devDependencies": {
-    "@goji/cli": "^0.7.6",
+    "@babel/core": "^7.15.0",
+    "@babel/plugin-transform-runtime": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
+    "@babel/preset-react": "^7.14.5",
+    "@babel/preset-typescript": "^7.15.0",
+    "babel-plugin-macros": "^3.1.0",
+    "@goji/cli": "^<%= version %>",
     "@types/classnames": "^2.2.10",
     "@types/css-modules": "^1.0.0",
     "@types/react": "^16.9.35",

--- a/packages/create-goji-app/tsconfig.json
+++ b/packages/create-goji-app/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "importHelpers": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "resolveJsonModule": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
The `create-goji-app` CLI seems not work.

I fixed it and adds some test cases.

The `packages/create-goji-app/src/__tests__/index.test.ts` will create a GojiJS app in `/tmp/.create-goji-app/my-goji-app` and run `yarn build` for it.