### PR TITLE
Add `within` method for testing library

### DIFF
--- a/packages/goji.js.org/docs/testing.md
+++ b/packages/goji.js.org/docs/testing.md
@@ -131,6 +131,21 @@ wrapper.debug(wrapper.getByTextId('test'));
 
 ![demo of debug](https://user-images.githubusercontent.com/1812118/89996259-28396080-dcbd-11ea-9e4d-f031c65b835f.png)
 
+### `within`
+
+If you'd like to restrict your query in specific container, you can use `within`.
+
+```tsx
+const Comp = () => (
+  <View testID="view">
+    <Button>Click me</Button>
+  </View>
+);
+const wrapper = render(<Comp />);
+const view = wrapper.getByTestId('view');
+const buttonInsideView = within(view).getByText('Click me');
+```
+
 ### `fireEvent`
 
 In your test cases, if you'd like to simulates the interactive events on the elements the

--- a/packages/goji.js.org/website/translated_docs/zh-CN/testing.md
+++ b/packages/goji.js.org/website/translated_docs/zh-CN/testing.md
@@ -116,9 +116,23 @@ wrapper.debug(wrapper.getByTextId('test'));
 
 ![调试示例](https://user-images.githubusercontent.com/1812118/89996259-28396080-dcbd-11ea-9e4d-f031c65b835f.png)
 
+### `within`
+
+如果你想在特定的节点中查询，可以使用</code> within `。</p>
+
+<pre><code class="tsx">const Comp = () => (
+  <View testID="view">
+    <Button>Click me</Button>
+  </View>
+);
+const wrapper = render(<Comp />);
+const view = wrapper.getByTestId('view');
+const buttonInsideView = within(view).getByText('Click me');
+`</pre>
+
 ### `fireEvent`
 
-在测试用例中，如果你想模拟在节点上的交互事件，可以使用`fireEvent` 。
+在测试用例中，如果你想模拟节点上的交互事件，可以使用`fireEvent.[event]` 。
 
 例如，要将文本输入到 `<Input testID="my-test-id">` 元素中，你可以使用：
 
@@ -155,13 +169,13 @@ act(() => {
 expect(wrapper.getByText('Count: 1')).toBeTruthy;
 ```
 
-请注意，所有 `fireEvent ` 方法已经被 `act`包裹了 ，因此没有必要再次使用。
+请注意，所有 `fireEvent ` 方法已经被 `act`包裹了 ，因此没有必要再次调用。
 
 ### `waitFor` 和 `waitForElement`
 
 ` waitFor ` 会捕获断言错误直到通过，否则会在超时后抛出异常。 它用于组件的异步测试。
 
-此为一个示例：
+这里是一个示例：
 
 ```tsx
 await waitFor(() => expect(wrapper.getByText('hello')).toBeTruthy());

--- a/packages/testing-library/src/__tests__/rendered.test.tsx
+++ b/packages/testing-library/src/__tests__/rendered.test.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { View, Button, Text } from '@goji/core';
-import { render } from '..';
+import { render, within } from '..';
 
 describe('rendered', () => {
-  const App = () => (
+  test('debug', () => {
+    const App = () => (
       <View testID="a">
         <Button onTap={() => {}}>hello</Button>
         <Text className="a b c">world</Text>
       </View>
     );
-  test('debug', () => {
+
     const wrapper = render(<App />);
     const log = jest.spyOn(console, 'log').mockImplementation(() => {});
     wrapper.debug(wrapper.getByTestId('a'));
@@ -18,5 +19,23 @@ describe('rendered', () => {
     expect(typeof output).toBe('string');
     expect(output).toMatchSnapshot();
     log.mockRestore();
+  });
+
+  test('within', () => {
+    const App = () => (
+      <>
+        <View testID="a">
+          <View testID="z" />
+        </View>
+        <View testID="b" />
+      </>
+    );
+
+    const wrapper = render(<App />);
+    expect(wrapper.getAllByTestId('z')).toHaveLength(1);
+    const viewA = wrapper.getByTestId('a');
+    expect(within(viewA).getAllByTestId('z')).toHaveLength(1);
+    const viewB = wrapper.getByTestId('b');
+    expect(() => within(viewB).getByTestId('z')).toThrow();
   });
 });

--- a/packages/testing-library/src/index.ts
+++ b/packages/testing-library/src/index.ts
@@ -15,3 +15,4 @@ export const render = (element: ReactElement) => {
 export { act };
 export { fireEvent } from './events';
 export { waitFor, waitForElement } from './wait';
+export { getQueriesForElement as within } from './rendered';

--- a/packages/testing-library/src/rendered.ts
+++ b/packages/testing-library/src/rendered.ts
@@ -35,6 +35,12 @@ function applyAll<T, Obj extends { [key: string]: (t: T, ...args: any) => any }>
 // to fix TS4023 error in `buildRenderResult`
 export type { TextMatch };
 
+export const getQueriesForElement = (container: ReactTestInstance) => ({
+  ...applyAll(byTextQueries, container),
+  ...applyAll(byTestIdQueries, container),
+  ...applyAll(byPropQueries, container),
+});
+
 export const buildRenderResult = (container: ReactTestInstance) => {
   // this render result APIs are inspired from @testing-library/react-native
   const wrapper = {
@@ -43,9 +49,7 @@ export const buildRenderResult = (container: ReactTestInstance) => {
       const allElements = byAnyQueries.queryAllByAny(container);
       return allElements[0] ?? null;
     },
-    ...applyAll(byTextQueries, container),
-    ...applyAll(byTestIdQueries, container),
-    ...applyAll(byPropQueries, container),
+    ...getQueriesForElement(container),
   };
 
   return wrapper;


### PR DESCRIPTION
If you'd like to restrict your query in specific container, you can use `within`.

```tsx
const Comp = () => (
  <View testID="view">
    <Button>Click me</Button>
  </View>
);
const wrapper = render(<Comp />);
const view = wrapper.getByTestId('view');
const buttonInsideView = within(view).getByText('Click me');
```

Inspired from:

https://github.com/testing-library/dom-testing-library/blob/d347302d6b17280b71505d55d0cb9cda376b95cc/src/get-queries-for-element.js#L13

https://github.com/callstack/react-native-testing-library/blob/e1d80d65fca628c014f8bd555670d9871f3ac6ee/src/within.js#L7