### PR TITLE
Fix an issue that <map> enable-poi should default to true

### DIFF
--- a/packages/core/src/components/componentsTypes.ts
+++ b/packages/core/src/components/componentsTypes.ts
@@ -722,6 +722,8 @@ export interface MapProps extends BaseProps {
   enableRotate?: boolean;
   enableSatellite?: boolean;
   enableTraffic?: boolean;
+  enablePoi?: boolean;
+  enableBuilding?: boolean;
   setting?: MapSetting;
   onMarkertap?: (e: any) => void;
   onLabeltap?: (e: any) => void;

--- a/packages/webpack-plugin/src/constants/components.ts
+++ b/packages/webpack-plugin/src/constants/components.ts
@@ -1627,7 +1627,7 @@ export const getBuiltInComponents = (target: GojiTarget): ComponentDesc[] =>
             required: false,
           },
           'enable-poi': {
-            defaultValue: false,
+            defaultValue: true,
             type: 'Boolean',
             required: false,
           },


### PR DESCRIPTION
According to [this document](https://developers.weixin.qq.com/miniprogram/dev/component/map.html) the default value of `enable-poi` should be `true` not `false`.

![image](https://user-images.githubusercontent.com/1812118/130551652-af5c2820-81d9-402f-8ade-4c253c0f1c74.png)
