### PR TITLE
Refactor SplitChunksPlugin and RuntimeChunkPlugin injecting logic

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -82,12 +82,10 @@ export const getWebpackConfig = ({
     },
     optimization: {
       minimize: nodeEnv === 'production',
-      runtimeChunk: GojiWebpackPlugin.runtimeChunkPlaceholder,
-      splitChunks: {
-        minChunks: 2,
-        minSize: 0,
-        cacheGroups: GojiWebpackPlugin.cacheGroupsPlaceholder,
-      },
+      // set `optimization.splitChunks` and `optimization.splitChunks` to `false`
+      // to disable built-in plugins and then we can load `GojiChunksWebpackPlugin` manually.
+      runtimeChunk: false,
+      splitChunks: false,
     },
     watchOptions: {
       poll: GojiWebpackPlugin.getPoll(),

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -5,11 +5,7 @@ import { GojiRuntimePlugin } from './plugins/runtime';
 import { GojiWebpackPluginOptions } from './types';
 import { DEFAULT_OPTIONS } from './constants';
 import { GojiSingletonRuntimeWebpackPlugin } from './plugins/singleton';
-import {
-  GojiSplitChunksWebpackPlugin,
-  cacheGroupsPlaceholder,
-  runtimeChunkPlaceholder,
-} from './plugins/splitChunks';
+import { GojiChunksWebpackPlugin } from './plugins/chunks';
 import { GojiShimPlugin } from './plugins/shim';
 import { getPoll } from './utils/polling';
 import { GojiProjectConfigPlugin } from './plugins/projectConfig';
@@ -38,16 +34,12 @@ export class GojiWebpackPlugin implements webpack.Plugin {
     new GojiCollectUsedComponentsWebpackPlugin(options).apply(compiler);
     new GojiBridgeWebpackPlugin(options).apply(compiler);
     new GojiEntryWebpackPlugin(options).apply(compiler);
-    new GojiSplitChunksWebpackPlugin(options).apply(compiler);
+    new GojiChunksWebpackPlugin(options).apply(compiler);
     new GojiRuntimePlugin(options).apply(compiler);
     new GojiSingletonRuntimeWebpackPlugin(options).apply(compiler);
     new GojiShimPlugin(options).apply(compiler);
     new GojiProjectConfigPlugin(options).apply(compiler);
   }
-
-  public static cacheGroupsPlaceholder = cacheGroupsPlaceholder;
-
-  public static runtimeChunkPlaceholder = runtimeChunkPlaceholder;
 
   public static getPoll = getPoll;
 


### PR DESCRIPTION
Before:

use placeholder in `webpack.config.js`
=> load `SplitChunksPlugin` and `RuntimeChunkPlugin` by [WebpackOptionsApply.js](https://github.com/webpack/webpack/blob/webpack-4/lib/WebpackOptionsApply.js)
=> parse `app.config.ts`by child compilers
=> inject `compiler.options`

After:

use `false` in `webpack.config.js`
=> prevent loading these plugins
=> parse `app.config.ts`by child compilers
=> load these plugins manually in `GojiChunksWebpackPlugin`

The benefit of this changing is that we no long need to depend on internal runtime order of `SplitChunksPlugin` and `RuntimeChunkPlugin`. We can create the instance of plugins after finishing param initializing.

P.S. This PR may also solve the `cacheGroups` compatibility issue in [Webpack 5](https://github.com/airbnb/goji-js/pull/22).