### PR TITLE
Refactor useRenderedEffect to support clean-up callback

### DIFF
--- a/packages/core/src/__tests__/helpers/adaptor.ts
+++ b/packages/core/src/__tests__/helpers/adaptor.ts
@@ -68,7 +68,7 @@ export class TestingAdaptorInstance extends AdaptorInstance {
 
     if (updateCallback) {
       delete this.updateCallbackMap[renderId];
-      this.updateCallbacks = this.updateCallbacks.filter(val => val === renderId);
+      this.updateCallbacks = this.updateCallbacks.filter(val => val !== renderId);
       updateCallback();
       return true;
     }

--- a/packages/core/src/lifecycles/universal/__tests__/renderedEffect.test.tsx
+++ b/packages/core/src/lifecycles/universal/__tests__/renderedEffect.test.tsx
@@ -1,0 +1,107 @@
+import React, { createRef } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useRenderedEffect } from '../renderedEffect';
+import { ContainerProvider } from '../../../components/container';
+import { EventProxy, EventProxyProvider } from '../../../components/eventProxy';
+
+describe('useRenderedEffect', () => {
+  test('callback works', () => {
+    const renderId = 0;
+    // TODO: find a better way to mock container
+    const container = {
+      eventProxyRef: createRef<EventProxy>(),
+      getRenderId() {
+        return renderId;
+      },
+    };
+    const callback = jest.fn() as jest.Mock<undefined, [string]>;
+    const useTest = () => {
+      useRenderedEffect(() => {
+        callback('rendered effect');
+      });
+    };
+    const wrapper = ({ children }) => (
+      <ContainerProvider container={container as any}>
+        <EventProxyProvider>{children}</EventProxyProvider>
+      </ContainerProvider>
+    );
+    const { result } = renderHook(useTest, { wrapper });
+    expect(result.error).toBeFalsy();
+
+    expect(callback.mock.calls).toEqual([]);
+    container.eventProxyRef.current?.emitEvent('internalRendered', renderId);
+    expect(callback.mock.calls).toEqual([['rendered effect']]);
+  });
+
+  test('clean-up works', () => {
+    let renderId = 0;
+    // TODO: find a better way to mock container
+    const container = {
+      eventProxyRef: createRef<EventProxy>(),
+      getRenderId: () => renderId,
+    };
+    const callback = jest.fn() as jest.Mock<undefined, [string]>;
+    const useTest = ({ count }: { count: number }) => {
+      useRenderedEffect(() => {
+        callback(`rendered effect ${count}`);
+
+        return () => callback(`rendered effect callback ${count}`);
+      });
+    };
+    const wrapper = ({ children }: React.PropsWithChildren<{ count: number }>) => (
+      <ContainerProvider container={container as any}>
+        <EventProxyProvider>{children}</EventProxyProvider>
+      </ContainerProvider>
+    );
+    const { result, rerender, unmount } = renderHook(useTest, {
+      wrapper,
+      initialProps: { count: 0 },
+    });
+
+    renderId = 1;
+    rerender({ count: 1 });
+
+    renderId = 2;
+    rerender({ count: 2 });
+
+    // renderId=2 and renderId=3 are merged
+    rerender({ count: 3 });
+
+    expect(result.error).toBeFalsy();
+
+    expect(callback.mock.calls).toEqual([]);
+
+    container.eventProxyRef.current?.emitEvent('internalRendered', 0);
+    expect(callback.mock.calls).toEqual([['rendered effect 0']]);
+
+    container.eventProxyRef.current?.emitEvent('internalRendered', 1);
+    expect(callback.mock.calls).toEqual([
+      ['rendered effect 0'],
+      ['rendered effect callback 0'],
+      ['rendered effect 1'],
+    ]);
+
+    container.eventProxyRef.current?.emitEvent('internalRendered', 2);
+    expect(callback.mock.calls).toEqual([
+      ['rendered effect 0'],
+      ['rendered effect callback 0'],
+      ['rendered effect 1'],
+      ['rendered effect callback 1'],
+      ['rendered effect 2'],
+      ['rendered effect callback 2'],
+      ['rendered effect 3'],
+    ]);
+
+    unmount();
+    expect(callback.mock.calls).toEqual([
+      ['rendered effect 0'],
+      ['rendered effect callback 0'],
+      ['rendered effect 1'],
+      ['rendered effect callback 1'],
+      ['rendered effect 2'],
+      ['rendered effect callback 2'],
+      ['rendered effect 3'],
+      ['rendered effect callback 3'],
+    ]);
+  });
+});

--- a/packages/core/src/utils/__tests__/effects.test.ts
+++ b/packages/core/src/utils/__tests__/effects.test.ts
@@ -61,6 +61,12 @@ describe('useImmediatelyEffect', () => {
     });
     expect(immediatelyEffectCallback).toBeCalledTimes(2);
     expect(immediatelyEffectUnsubscribedCallback).toBeCalledTimes(1);
+    // update deps with same value
+    act(() => {
+      result.current.setCount(c => c);
+    });
+    expect(immediatelyEffectCallback).toBeCalledTimes(2); // should not run
+    expect(immediatelyEffectUnsubscribedCallback).toBeCalledTimes(1);
     // update non-deps
     act(() => {
       result.current.setAnother(c => c + 1);

--- a/packages/core/src/utils/effects.ts
+++ b/packages/core/src/utils/effects.ts
@@ -1,23 +1,27 @@
-import { useRef, useEffect, useCallback, EffectCallback, useMemo } from 'react';
+import { useRef, useEffect, EffectCallback, useMemo } from 'react';
 
-// this hook will run during component rendering rather than after it
-// it is useful to update component in the same rendering tick like https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops
-// NOTE: this hook might not work in concurrent mode
+/**
+ * This hook runs during component rendering rather than after it
+ * It is useful when updating component in the same rendering tick like https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops
+ * @note this hook might not work in concurrent mode
+ */
 export const useImmediatelyEffect = <T extends Array<any>>(callback: EffectCallback, deps?: T) => {
   const unsubscribeRef = useRef<ReturnType<EffectCallback>>(undefined);
 
-  const resolveUnsubscribe = useCallback(() => {
-    if (unsubscribeRef.current) {
-      unsubscribeRef.current();
-      unsubscribeRef.current = undefined;
-    }
-  }, []);
-
   // re-run callback only if `deps` changed
   unsubscribeRef.current = useMemo(() => {
-    resolveUnsubscribe();
+    const unsubscribe = unsubscribeRef.current;
+    unsubscribeRef.current = undefined;
+    unsubscribe?.();
     return callback();
   }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => resolveUnsubscribe, [resolveUnsubscribe]);
+  useEffect(
+    () => () => {
+      const unsubscribe = unsubscribeRef.current;
+      unsubscribeRef.current = undefined;
+      unsubscribe?.();
+    },
+    [],
+  );
 };


### PR DESCRIPTION
Usage:

```tsx
useRenderedEffect(() => {
  // init here
  return () => {
    // clean-up here
  }
}, []);
```

Here is an example with Goji blocking mode enabled. A React component commits ( renders ) 3 times, its 2nd/3rd commit happen while 1st setData is still working.

![useRenderedEffect (1)](https://user-images.githubusercontent.com/1812118/131434192-1ce0c811-f2f5-4874-845c-f29baa805a43.png)


<details>
<summary>source</summary>

```
title useRenderedEffect

note over React: mount
React->buffer: commit a
buffer->setData: a
setData->(2)webview: render a
React->buffer: commit b
React->buffer: commit c
webview->(2)setData: done a
setData-->useRenderedEffect: effect a
buffer->setData: b+c
setData->(2)webview: render b+c
webview->(2)setData: done b+c
setData-->useRenderedEffect: clean-up a
setData-->useRenderedEffect: effect b
setData-->useRenderedEffect: clean-up b
setData-->useRenderedEffect: effect c
note over React: unmount
React-->useRenderedEffect: clean-up c
```
</details>

