### PR TITLE
Implement EventChannel / CachedEventChannel as replacement of EventEmitter

### DIFF
--- a/packages/core/src/reconciler/instance.ts
+++ b/packages/core/src/reconciler/instance.ts
@@ -71,10 +71,10 @@ const shouldUseSubtree = () =>
 
 export class ElementInstance extends BaseInstance {
   public constructor(
-    public type: string,
+    public override type: string,
     public props: InstanceProps,
     public children: Array<ElementInstance | TextInstance> = [],
-    public container: Container,
+    public override container: Container,
   ) {
     super(type, container);
     this.props = removeChildrenFromProps(props);
@@ -292,7 +292,7 @@ export class ElementInstance extends BaseInstance {
 }
 
 export class TextInstance extends BaseInstance {
-  public constructor(public text: string, public container: Container) {
+  public constructor(public text: string, public override container: Container) {
     super(TYPE_TEXT, container);
   }
 

--- a/packages/core/src/utils/__tests__/eventChannel.test.ts
+++ b/packages/core/src/utils/__tests__/eventChannel.test.ts
@@ -1,4 +1,4 @@
-import { EventChannel } from '../eventChannel';
+import { CachedEventChannel, EventChannel } from '../eventChannel';
 
 describe('EventChannel', () => {
   test('on and emit', () => {
@@ -161,5 +161,78 @@ describe('EventChannel', () => {
     expect(listener2).toBeCalledTimes(0);
     expect(listener3).toBeCalledTimes(1);
     expect(listener4).toBeCalledTimes(0);
+  });
+});
+
+describe('CachedEventChannel', () => {
+  test('on with cache', () => {
+    const channel = new CachedEventChannel<string>();
+    channel.emit('a');
+    const listener1 = jest.fn();
+    channel.on(listener1);
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener1).toBeCalledWith('a');
+    channel.emit('b');
+    expect(listener1).toBeCalledTimes(2);
+    expect(listener1).toBeCalledWith('b');
+  });
+
+  test('once with cache', () => {
+    const channel = new CachedEventChannel<string>();
+    channel.emit('a');
+    const listener1 = jest.fn();
+    channel.once(listener1);
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener1).toBeCalledWith('a');
+    channel.emit('b');
+    expect(listener1).toBeCalledTimes(1);
+  });
+
+  test('filteredOnce with cache', () => {
+    const channel = new CachedEventChannel<string>();
+    channel.emit('a');
+    const listener1 = jest.fn();
+    channel.filteredOnce(data => data === 'a', listener1);
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener1).toBeCalledWith('a');
+    channel.emit('b');
+    expect(listener1).toBeCalledTimes(1);
+  });
+
+  test('on without cache', () => {
+    const channel = new CachedEventChannel<string>();
+    const listener1 = jest.fn();
+    channel.on(listener1);
+    expect(listener1).toBeCalledTimes(0);
+    channel.emit('a');
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener1).toBeCalledWith('a');
+    expect(channel.listenerCount()).toBe(1);
+  });
+
+  test('once without cache', () => {
+    const channel = new CachedEventChannel<string>();
+    const listener1 = jest.fn();
+    channel.once(listener1);
+    expect(listener1).toBeCalledTimes(0);
+    channel.emit('a');
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener1).toBeCalledWith('a');
+    channel.emit('b');
+    expect(listener1).toBeCalledTimes(1);
+    expect(channel.listenerCount()).toBe(0);
+  });
+
+  test('filteredOnce without cache', () => {
+    const channel = new CachedEventChannel<string>();
+    const listener1 = jest.fn();
+    channel.filteredOnce(data => data === 'b', listener1);
+    expect(listener1).toBeCalledTimes(0);
+    channel.emit('a');
+    expect(listener1).toBeCalledTimes(0);
+    channel.emit('b');
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener1).toBeCalledWith('b');
+    expect(channel.listenerCount()).toBe(0);
   });
 });

--- a/packages/core/src/utils/__tests__/eventChannel.test.ts
+++ b/packages/core/src/utils/__tests__/eventChannel.test.ts
@@ -1,0 +1,165 @@
+import { EventChannel } from '../eventChannel';
+
+describe('EventChannel', () => {
+  test('on and emit', () => {
+    const channel = new EventChannel<{ first: string; last: string }, string>();
+    const listener1 = jest
+      .fn()
+      .mockImplementation(
+        ({ first, last }: { first: string; last: string }) => `1 ${first} ${last}`,
+      );
+    const listener2 = jest
+      .fn()
+      .mockImplementation(
+        ({ first, last }: { first: string; last: string }) => `2 ${first} ${last}`,
+      );
+    const listener3 = jest
+      .fn()
+      .mockImplementation(
+        ({ first, last }: { first: string; last: string }) => `3 ${first} ${last}`,
+      );
+    channel.on(listener1);
+    channel.on(listener2);
+    channel.on(listener3);
+    expect(channel.listenerCount()).toBe(3);
+    expect(channel.emit({ first: 'hello', last: 'world' })).toEqual([
+      '1 hello world',
+      '2 hello world',
+      '3 hello world',
+    ]);
+    expect(channel.emit({ first: 'hello', last: 'react' })).toEqual([
+      '1 hello react',
+      '2 hello react',
+      '3 hello react',
+    ]);
+    expect(channel.emit({ first: 'hello', last: 'goji' })).toEqual([
+      '1 hello goji',
+      '2 hello goji',
+      '3 hello goji',
+    ]);
+    expect(listener1).toBeCalledTimes(3);
+    expect(listener2).toBeCalledTimes(3);
+    expect(listener3).toBeCalledTimes(3);
+  });
+
+  test('once and emit', () => {
+    const channel = new EventChannel<{ first: string; last: string }, string>();
+    const listener1 = jest
+      .fn()
+      .mockImplementation(
+        ({ first, last }: { first: string; last: string }) => `1 ${first} ${last}`,
+      );
+    const listener2 = jest
+      .fn()
+      .mockImplementation(
+        ({ first, last }: { first: string; last: string }) => `2 ${first} ${last}`,
+      );
+    const listener3 = jest
+      .fn()
+      .mockImplementation(
+        ({ first, last }: { first: string; last: string }) => `3 ${first} ${last}`,
+      );
+    channel.once(listener1);
+    channel.once(listener2);
+    channel.once(listener3);
+    expect(channel.listenerCount()).toBe(3);
+    expect(channel.emit({ first: 'hello', last: 'world' })).toEqual([
+      '1 hello world',
+      '2 hello world',
+      '3 hello world',
+    ]);
+    expect(channel.listenerCount()).toBe(0);
+    expect(channel.emit({ first: 'hello', last: 'react' })).toEqual([]);
+    expect(channel.emit({ first: 'hello', last: 'goji' })).toEqual([]);
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener2).toBeCalledTimes(1);
+    expect(listener3).toBeCalledTimes(1);
+  });
+
+  test('filteredOnce and emit', () => {
+    const channel = new EventChannel<{ first: string; last: string }, string>();
+    const listener1 = jest.fn();
+    channel.filteredOnce(data => data.last === 'goji', listener1);
+
+    channel.emit({ first: 'hello', last: 'world' });
+    expect(listener1).toBeCalledTimes(0);
+    expect(channel.listenerCount()).toBe(1);
+
+    channel.emit({ first: 'hello', last: 'goji' });
+    expect(listener1).toBeCalledTimes(1);
+    expect(channel.listenerCount()).toBe(0);
+
+    channel.emit({ first: 'hello', last: 'react' });
+    expect(listener1).toBeCalledTimes(1);
+    expect(channel.listenerCount()).toBe(0);
+  });
+
+  describe('off and offAll', () => {
+    const channel = new EventChannel();
+    const listener1 = jest.fn();
+    const listener2 = jest.fn();
+    const listener3 = jest.fn();
+    channel.on(listener1);
+    const off2 = channel.on(listener2);
+    channel.on(listener3);
+
+    beforeEach(() => {
+      listener1.mockClear();
+      listener2.mockClear();
+      listener3.mockClear();
+    });
+
+    test('not match', () => {
+      channel.off(() => {});
+      channel.emit();
+      expect(listener1).toBeCalledTimes(1);
+    });
+
+    test('off listener', () => {
+      channel.off(listener1);
+      channel.emit();
+      expect(listener1).not.toBeCalled();
+    });
+
+    test(`off by on's clean-up function`, () => {
+      off2();
+      channel.emit();
+      expect(listener2).not.toBeCalled();
+    });
+
+    test(`off by once's clean-up function`, () => {
+      const listener = jest.fn();
+      const off = channel.once(listener);
+      off();
+      channel.emit();
+      expect(listener).not.toBeCalled();
+    });
+
+    test('offAll', () => {
+      channel.offAll();
+      channel.emit();
+      expect(listener1).not.toBeCalled();
+    });
+  });
+
+  test('off while emitting', () => {
+    const channel = new EventChannel();
+    const listener2 = jest.fn();
+    const listener1 = jest.fn().mockImplementation(() => {
+      channel.off(listener2);
+    });
+    const listener3 = jest.fn().mockImplementation(() => {
+      channel.offAll();
+    });
+    const listener4 = jest.fn();
+    channel.on(listener1);
+    channel.on(listener2);
+    channel.on(listener3);
+    channel.on(listener4);
+    channel.emit();
+    expect(listener1).toBeCalledTimes(1);
+    expect(listener2).toBeCalledTimes(0);
+    expect(listener3).toBeCalledTimes(1);
+    expect(listener4).toBeCalledTimes(0);
+  });
+});

--- a/packages/core/src/utils/eventChannel.ts
+++ b/packages/core/src/utils/eventChannel.ts
@@ -1,0 +1,104 @@
+type Callback<T, R> = T extends undefined ? (data?: T) => R : (data: T) => R;
+
+type TaskResult<R> = { success: false } | { success: true; result: R };
+
+class EventChannelTask<T = undefined, R = void> {
+  public constructor(
+    public taskCallback: (this: EventChannelTask<T, R>, data: T) => TaskResult<R>,
+    public originalCallback: Callback<T, R>,
+    public ttl: number,
+  ) {}
+}
+
+/**
+ * `EventChannel` is a pub-sub event hub implementation.
+ * It's mainly inspired from built-in `events` library but also provides several important new features.
+ * 1. `EventChannel` is type-safed.
+ * 2. No `event name`, use data payload instead.
+ * 3. `EventChannel` provides a duplexed channel from both pub-to-sub and sub-to-pub by returning
+ * a value from listener callback. See example bellow.
+ * @example
+ * const channel = new EventChannel<string, string>;
+ * channel.on(msg => msg.toUpperCase());
+ * channel.on(msg => msg.toLowerCase());
+ * channel.emit('Hello'); // returns ['HELLO', 'hello']
+ */
+export class EventChannel<T = undefined, R = void> {
+  private tasks: Array<EventChannelTask<T, R>> = [];
+
+  private enqueueTask(callback: Callback<T, R>, times: number, filter: Callback<T, boolean>) {
+    const channel = this;
+    const task = new EventChannelTask<T, R>(
+      function taskCallback(data) {
+        if (this.ttl <= 0) {
+          channel.off(this.originalCallback);
+          return { success: false };
+        }
+        if (filter(data)) {
+          this.ttl -= 1;
+          if (this.ttl <= 0) {
+            channel.off(this.originalCallback);
+          }
+          return { success: true, result: callback(data) };
+        }
+
+        return { success: false };
+      },
+      callback,
+      times,
+    );
+    this.tasks.push(task);
+
+    return () => this.off(callback);
+  }
+
+  public on(callback: Callback<T, R>) {
+    return this.enqueueTask(callback, Infinity, () => true);
+  }
+
+  public once(callback: Callback<T, R>) {
+    return this.enqueueTask(callback, 1, () => true);
+  }
+
+  /**
+   * use `match` to filter events and run `callback` only once if matched
+   */
+  public filteredOnce(filter: Callback<T, boolean>, callback: Callback<T, R>) {
+    return this.enqueueTask(callback, 1, filter);
+  }
+
+  public emit: Callback<T, Array<R>> = data => {
+    const results: Array<R> = [];
+    // cache the listeners in case of being modified during emitting
+    const forkedTasks = [...this.tasks];
+    for (let index = 0; index < forkedTasks.length; index += 1) {
+      const task = forkedTasks[index];
+      const result = task.taskCallback(data);
+      if (result.success) {
+        results.push(result.result);
+      }
+    }
+    return results;
+  };
+
+  public off(callback: Callback<T, R>) {
+    const pos = this.tasks.findIndex(listener => listener.originalCallback === callback);
+    if (pos !== -1) {
+      // set `ttl` to 0 to prevent unexpected call from cached closure
+      this.tasks[pos].ttl = 0;
+      this.tasks.splice(pos, 1);
+    }
+  }
+
+  public offAll() {
+    for (const task of this.tasks) {
+      // set `ttl` to 0 to prevent unexpected call from cached closure
+      task.ttl = 0;
+    }
+    this.tasks = [];
+  }
+
+  public listenerCount() {
+    return this.tasks.length;
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "importHelpers": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "noImplicitOverride": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
# What

`EventChannel` is a pub-sub event hub implementation.

It's mainly inspired from built-in `events` library but also provides several important new features.

1. `EventChannel` is type-safed.

2. No `event name`, use data payload instead.

3. `EventChannel` provides a duplexed channel from both pub-to-sub and sub-to-pub by returning a value from listener callback. See example bellow.

```tsx
const channel = new EventChannel<string, string>;
channel.on(msg => msg.toUpperCase());
channel.on(msg => msg.toLowerCase());
channel.emit('Hello'); // returns ['HELLO', 'hello']
```

# Why

1. EventChannel provides more features than EventEmitter.

2. EventChannel cost less lines of code ( ~ 180 lines) than [EventEmitter](https://github.com/browserify/events/blob/main/events.js) ( ~ 500 lines )

3. Prevent `MaxListenersExceededWarning`.

![image](https://user-images.githubusercontent.com/1812118/134278120-1e3b3bdb-ea31-4e42-86c1-23124a5a54f5.png)
