### PR TITLE
Refactor EventProxy with EventChannel

### DIFF
--- a/packages/core/src/adaptor/wechat.tsx
+++ b/packages/core/src/adaptor/wechat.tsx
@@ -6,12 +6,9 @@ import { Adaptor, AdaptorInstance, AdaptorType, ExportComponentMeta } from './co
 import { gojiEvents } from '../events';
 import { useInternalComponentUpdate } from '../lifecycles/native/hooks';
 import {
-  WechatLifecycleName,
   OnScrollOptions,
   OnShareAppMessageOptions,
-  AlipayLifecycleName,
   OnResizeOptions,
-  InternalLifecycleName,
   OnTabItemTapOptions,
 } from '../lifecycles/types';
 
@@ -111,23 +108,23 @@ export class WeChatAdaptor extends Adaptor {
 
         container.render(element);
 
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onLoad', options);
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onLoad.emit(options);
       },
 
       onReady(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onReady');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onReady.emit();
       },
 
       onShow(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onShow');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onShow.emit();
       },
 
       onHide(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onHide');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onHide.emit();
       },
 
       onUnload(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onUnload');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onUnload.emit();
 
         if (this.__GOJI_CONTAINER) {
           this.__GOJI_CONTAINER.render(null);
@@ -136,22 +133,20 @@ export class WeChatAdaptor extends Adaptor {
       },
 
       onPullDownRefresh(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onPullDownRefresh');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onPullDownRefresh.emit();
       },
 
       onReachBottom(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onReachBottom');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onReachBottom.emit();
       },
 
       onPageScroll(this: WeChatInstance, options: OnScrollOptions) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onPageScroll', options);
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onPageScroll.emit(options);
       },
 
       onShareAppMessage(this: WeChatInstance, options: OnShareAppMessageOptions) {
-        const results = this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>(
-          'onShareAppMessage',
-          options,
-        );
+        const results =
+          this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onShareAppMessage.emit(options);
 
         if (results && results.length > 1) {
           console.warn(
@@ -159,32 +154,32 @@ export class WeChatAdaptor extends Adaptor {
           );
         }
 
-        return results?.[results.length - 1];
+        return results[0];
       },
 
       onResize(this: WeChatInstance, options: OnResizeOptions) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onResize', options);
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onResize.emit(options);
       },
 
       onTabItemTap(this: WeChatInstance, options: OnTabItemTapOptions) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<WechatLifecycleName>('onTabItemTap', options);
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onTabItemTap.emit(options);
       },
 
       // FIXME: Alipay specific lifecycles. We should fork them to alipay adaptor later
       onTitleClick(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<AlipayLifecycleName>('onTitleClick');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onTitleClick.emit();
       },
 
       onOptionMenuClick(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<AlipayLifecycleName>('onOptionMenuClick');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onOptionMenuClick.emit();
       },
 
       onPopMenuClick(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<AlipayLifecycleName>('onPopMenuClick');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onPopMenuClick.emit();
       },
 
       onPullIntercept(this: WeChatInstance) {
-        this.__GOJI_CONTAINER!.emitLifecycleEvent<AlipayLifecycleName>('onPullIntercept');
+        this.__GOJI_CONTAINER!.eventProxy.lifecycleChannel.onPullIntercept.emit();
       },
     };
 
@@ -229,12 +224,9 @@ export class WeChatAdaptor extends Adaptor {
               if (!this.__GOJI_CONTAINER) {
                 return;
               }
-              this.__GOJI_CONTAINER.emitLifecycleEvent<InternalLifecycleName>(
-                'internalComponentUpdate',
-                {
-                  [prop]: newVal,
-                },
-              );
+              this.__GOJI_CONTAINER.eventProxy.internalChannels.exportedComponentUpdate.emit({
+                [prop]: newVal,
+              });
             },
           })),
         ),
@@ -249,8 +241,7 @@ export class WeChatAdaptor extends Adaptor {
               </ExportComponentWrapper>,
             );
 
-            this.__GOJI_CONTAINER.emitLifecycleEvent<InternalLifecycleName>(
-              'internalComponentUpdate',
+            this.__GOJI_CONTAINER.eventProxy.internalChannels.exportedComponentUpdate.emit(
               this.properties,
             );
           },

--- a/packages/core/src/components/__tests__/eventProxy.test.tsx
+++ b/packages/core/src/components/__tests__/eventProxy.test.tsx
@@ -1,45 +1,42 @@
-import React, { createRef, useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { View } from '../..';
 import { act } from '../../testUtils';
-import { EventProxyProvider, useEventProxy } from '../eventProxy';
+import { createEventProxy, useEventProxy } from '../eventProxy';
 import { render } from '../../__tests__/helpers';
 import { ContainerProvider } from '../container';
 
 describe('eventProxy', () => {
   test('batched', () => {
     let renderCount = 0;
-    const eventProxyRef = createRef<{ emitEvent(name: string, data?: any): void }>();
+    const eventProxy = createEventProxy();
 
     const App = () => {
       const [, forceRender] = useReducer(s => s + 1, 0);
       const eventProxyContext = useEventProxy();
 
-      useEffect(() => eventProxyContext.handleEvent('test', () => {
-          forceRender();
-          forceRender();
-        }), [eventProxyContext]);
+      useEffect(
+        () =>
+          eventProxyContext.lifecycleChannel.onLoad.on(() => {
+            forceRender();
+            forceRender();
+          }),
+        [eventProxyContext],
+      );
       renderCount += 1;
       return <View />;
     };
 
     act(() => {
       render(
-        <ContainerProvider container={{ eventProxyRef } as any}>
-          <EventProxyProvider>
-            <App />
-          </EventProxyProvider>
+        <ContainerProvider container={{ eventProxy } as any}>
+          <App />
         </ContainerProvider>,
       );
     });
     expect(renderCount).toBe(1);
 
-    // unknown event
-    eventProxyRef.current!.emitEvent('unknown');
-    act(() => {});
-    expect(renderCount).toBe(1);
-
     // should batch updates
-    eventProxyRef.current!.emitEvent('test');
+    eventProxy.lifecycleChannel.onLoad.emit({});
     act(() => {});
     expect(renderCount).toBe(2);
   });

--- a/packages/core/src/components/index.tsx
+++ b/packages/core/src/components/index.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithChildren } from 'react';
 import { UniversalHooksProvider } from '../lifecycles/universal/provider';
-import { EventProxyProvider } from './eventProxy';
 import { PortalProvider } from '../portal';
 import { Container } from '../container';
 import { ContainerProvider } from './container';
@@ -12,13 +11,11 @@ export const GojiProvider = ({
 }: PropsWithChildren<{
   container: Container;
 }>) => (
-    <ContainerProvider container={container}>
-      <EventProxyProvider>
-        <UniversalHooksProvider>
-          <PortalProvider>
-            <PartialProvider>{children}</PartialProvider>
-          </PortalProvider>
-        </UniversalHooksProvider>
-      </EventProxyProvider>
-    </ContainerProvider>
-  );
+  <ContainerProvider container={container}>
+    <UniversalHooksProvider>
+      <PortalProvider>
+        <PartialProvider>{children}</PartialProvider>
+      </PortalProvider>
+    </UniversalHooksProvider>
+  </ContainerProvider>
+);

--- a/packages/core/src/lifecycles/native/__tests__/hooks.test.tsx
+++ b/packages/core/src/lifecycles/native/__tests__/hooks.test.tsx
@@ -1,10 +1,10 @@
-import React, { useState, createRef } from 'react';
+import React, { useState } from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { View } from '../../..';
 import { useOnPageScroll } from '../hooks';
 import { GojiProvider } from '../../../components';
-import { EventProxy } from '../../../components/eventProxy';
+import { createEventProxy } from '../../../components/eventProxy';
 
 describe('native lifecycles', () => {
   it('onLoad works', () => {
@@ -17,9 +17,9 @@ describe('native lifecycles', () => {
       });
       return <View>value is {value}</View>;
     };
-    const eventProxyRef = createRef<EventProxy>();
+    const eventProxy = createEventProxy();
     const wrapper = mount(
-      <GojiProvider container={{ eventProxyRef } as any}>
+      <GojiProvider container={{ eventProxy } as any}>
         <View className="text">hello, world!</View>
         <App />
       </GojiProvider>,
@@ -31,7 +31,7 @@ describe('native lifecycles', () => {
     // trigger onLoad
     const mockOnPageScroll = { scrollTop: 1024 };
     act(() => {
-      eventProxyRef.current!.emitEvent('onPageScroll', mockOnPageScroll);
+      eventProxy.lifecycleChannel.onPageScroll.emit(mockOnPageScroll);
     });
 
     expect(onPageScrollOptions).toEqual(mockOnPageScroll);

--- a/packages/core/src/lifecycles/native/hooks.ts
+++ b/packages/core/src/lifecycles/native/hooks.ts
@@ -3,12 +3,14 @@ import {
   OnShareAppMessageOptions,
   OnResizeOptions,
   OnTabItemTapOptions,
-  LifecycleName,
 } from '../types';
 import { useImmediatelyEffect } from '../../utils/effects';
-import { useEventProxy } from '../../components/eventProxy';
+import { EventProxy, useEventProxy } from '../../components/eventProxy';
+import { EventChannel } from '../../utils/eventChannel';
 
-const createLifecycleHook = <T = undefined>(name: LifecycleName) => (callback: (data: T) => void, deps?: Array<any>) => {
+const createLifecycleHook =
+  <T = undefined>(channelSelector: (eventProxy: EventProxy) => EventChannel<any, any>) =>
+  (callback: (data: T) => void, deps?: Array<any>) => {
     const eventProxyContext = useEventProxy();
     // must use `useImmediatelyEffect` instead of `useEffect`
     useImmediatelyEffect(() => {
@@ -17,24 +19,31 @@ const createLifecycleHook = <T = undefined>(name: LifecycleName) => (callback: (
           'Cannot found `eventProxyContext`. This might be an internal error in GojiJS.',
         );
       }
-      return eventProxyContext.handleEvent(name, callback as any);
+      return channelSelector(eventProxyContext).on(callback as any);
     }, deps); // eslint-disable-line react-hooks/exhaustive-deps
   };
 
-export const useOnReady = createLifecycleHook('onReady');
-export const useOnUnload = createLifecycleHook('onUnload');
-export const useOnPullDownRefresh = createLifecycleHook('onPullDownRefresh');
-export const useOnReachBottom = createLifecycleHook('onReachBottom');
-export const useOnPageScroll = createLifecycleHook<OnScrollOptions>('onPageScroll');
-export const useOnShareAppMessage =
-  createLifecycleHook<OnShareAppMessageOptions>('onShareAppMessage');
-export const useOnResize = createLifecycleHook<OnResizeOptions>('onResize');
-export const useOnTabItemTap = createLifecycleHook<OnTabItemTapOptions>('onTabItemTap');
+export const useOnReady = createLifecycleHook(_ => _.lifecycleChannel.onReady);
+export const useOnUnload = createLifecycleHook(_ => _.lifecycleChannel.onUnload);
+export const useOnPullDownRefresh = createLifecycleHook(_ => _.lifecycleChannel.onPullDownRefresh);
+export const useOnReachBottom = createLifecycleHook(_ => _.lifecycleChannel.onReachBottom);
+export const useOnPageScroll = createLifecycleHook<OnScrollOptions>(
+  _ => _.lifecycleChannel.onPageScroll,
+);
+export const useOnShareAppMessage = createLifecycleHook<OnShareAppMessageOptions>(
+  _ => _.lifecycleChannel.onShareAppMessage,
+);
+export const useOnResize = createLifecycleHook<OnResizeOptions>(_ => _.lifecycleChannel.onResize);
+export const useOnTabItemTap = createLifecycleHook<OnTabItemTapOptions>(
+  _ => _.lifecycleChannel.onTabItemTap,
+);
 // alipay only
-export const useOnTitleClick = createLifecycleHook('onTitleClick');
-export const useOnOptionMenuClick = createLifecycleHook('onOptionMenuClick');
-export const useOnPopMenuClick = createLifecycleHook('onPopMenuClick');
-export const useOnPullIntercept = createLifecycleHook('onPullIntercept');
+export const useOnTitleClick = createLifecycleHook(_ => _.lifecycleChannel.onTitleClick);
+export const useOnOptionMenuClick = createLifecycleHook(_ => _.lifecycleChannel.onOptionMenuClick);
+export const useOnPopMenuClick = createLifecycleHook(_ => _.lifecycleChannel.onPopMenuClick);
+export const useOnPullIntercept = createLifecycleHook(_ => _.lifecycleChannel.onPullIntercept);
 
 // FIXME: internal hooks, consider to move to other folder
-export const useInternalComponentUpdate = createLifecycleHook<object>('internalComponentUpdate');
+export const useInternalComponentUpdate = createLifecycleHook<object>(
+  _ => _.internalChannels.exportedComponentUpdate,
+);

--- a/packages/core/src/lifecycles/types.ts
+++ b/packages/core/src/lifecycles/types.ts
@@ -1,28 +1,3 @@
-export type WechatLifecycleName =
-  | 'onLoad'
-  | 'onShow'
-  | 'onReady'
-  | 'onHide'
-  | 'onUnload'
-  | 'onUnload'
-  | 'onPullDownRefresh'
-  | 'onReachBottom'
-  | 'onPageScroll'
-  | 'onShareAppMessage'
-  | 'onResize'
-  | 'onTabItemTap';
-
-export type AlipayLifecycleName =
-  | WechatLifecycleName
-  | 'onTitleClick'
-  | 'onOptionMenuClick'
-  | 'onPopMenuClick'
-  | 'onPullIntercept';
-
-export type InternalLifecycleName = 'internalComponentUpdate' | 'internalRendered';
-
-export type LifecycleName = WechatLifecycleName | AlipayLifecycleName | InternalLifecycleName;
-
 export type UniversalLifecycleName = 'loadOptions' | 'visibility' | 'renderedEffect';
 
 export interface OnLoadOptions {
@@ -36,6 +11,18 @@ export interface OnScrollOptions {
 export interface OnShareAppMessageOptions {
   from: 'button' | 'menu';
   target: object | undefined;
+  webViewUrl?: string;
+}
+
+export interface OnShareAppMessageReturn {
+  title?: string;
+  imageUrl?: string;
+  path?: string;
+  promise?: Promise<{
+    title?: string;
+    imageUrl?: string;
+    path?: string;
+  }>;
 }
 
 export interface OnResizeOptions {

--- a/packages/core/src/lifecycles/universal/__tests__/hooks.test.tsx
+++ b/packages/core/src/lifecycles/universal/__tests__/hooks.test.tsx
@@ -1,10 +1,10 @@
-import React, { useState, createRef, useReducer } from 'react';
+import React, { useState, useReducer } from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { TestingAdaptor } from '../../../__tests__/helpers/adaptor';
 import { View, useLoadOptions, useRenderedEffect, setGojiBlockingMode } from '../../..';
 import { GojiProvider } from '../../../components';
-import { EventProxy } from '../../../components/eventProxy';
+import { createEventProxy } from '../../../components/eventProxy';
 import { render, RenderResult } from '../../../__tests__/helpers';
 
 describe('universal lifecycles', () => {
@@ -28,9 +28,9 @@ describe('universal lifecycles', () => {
 
       return showComp ? <Comp /> : null;
     };
-    const eventProxyRef = createRef<EventProxy>();
+    const eventProxy = createEventProxy();
     const wrapper = mount(
-      <GojiProvider container={{ eventProxyRef } as any}>
+      <GojiProvider container={{ eventProxy } as any}>
         <App />
       </GojiProvider>,
     );
@@ -38,7 +38,7 @@ describe('universal lifecycles', () => {
     // trigger onLoad
     const mockOnLoadOptions = { key: 'haha' };
     act(() => {
-      eventProxyRef.current!.emitEvent('onLoad', mockOnLoadOptions);
+      eventProxy.lifecycleChannel.onLoad.emit(mockOnLoadOptions);
     });
 
     expect(onLoadOptions).toBeUndefined();

--- a/packages/core/src/lifecycles/universal/provider.tsx
+++ b/packages/core/src/lifecycles/universal/provider.tsx
@@ -29,13 +29,23 @@ export const UniversalHooksProvider = ({ children }: React.PropsWithChildren<{}>
 
   // must use `useImmediatelyEffect` instead of `useEffect`
   // useLoadOptions
-  useImmediatelyEffect(() => eventProxyContext.handleEvent('onLoad', (options: OnLoadOptions) =>
-      emit('loadOptions', options),
-    ), [emit, eventProxyContext]);
+  useImmediatelyEffect(
+    () =>
+      eventProxyContext.lifecycleChannel.onLoad.on((options: OnLoadOptions) =>
+        emit('loadOptions', options),
+      ),
+    [emit, eventProxyContext],
+  );
 
   // useVisibility
-  useImmediatelyEffect(() => eventProxyContext.handleEvent('onShow', () => emit('visibility', true)), [emit, eventProxyContext]);
-  useImmediatelyEffect(() => eventProxyContext.handleEvent('onHide', () => emit('visibility', false)), [emit, eventProxyContext]);
+  useImmediatelyEffect(
+    () => eventProxyContext.lifecycleChannel.onLoad.on(() => emit('visibility', true)),
+    [emit, eventProxyContext],
+  );
+  useImmediatelyEffect(
+    () => eventProxyContext.lifecycleChannel.onLoad.on(() => emit('visibility', false)),
+    [emit, eventProxyContext],
+  );
 
   const { Provider } = UniversalHooksContext;
 


### PR DESCRIPTION
`EventProxy` is the most important event bus in GojiJS. It enabled communication between container ( React Reconciler ) and React components.

According to last PR https://github.com/airbnb/goji-js/pull/117 I refactor the `EventProxy` in new `EventChannel` class and deprecate the `events`.