### PR TITLE
Refactor all events with EventChannel

### DIFF
--- a/packages/core/src/lifecycles/universal/context.ts
+++ b/packages/core/src/lifecycles/universal/context.ts
@@ -1,10 +1,12 @@
 import { createContext } from 'react';
-import { EventEmitter } from 'events';
-import { UniversalLifecycleName } from '../types';
+import { CachedEventChannel } from '../../utils/eventChannel';
+import { OnLoadOptions } from '../types';
 
-interface UniversalHooksContextType {
-  cache: Map<UniversalLifecycleName, any>;
-  events: EventEmitter;
+export interface UniversalHooksContextType {
+  universalLifecycleChannel: {
+    loadOptions: CachedEventChannel<OnLoadOptions>;
+    visibility: CachedEventChannel<boolean>;
+  };
 }
 
 export const UniversalHooksContext = createContext<UniversalHooksContextType | undefined>(

--- a/packages/core/src/reconciler/hostConfig.ts
+++ b/packages/core/src/reconciler/hostConfig.ts
@@ -38,7 +38,10 @@ export const hostConfig: GojiHostConfig<
       } else {
         // if `attached` have not run, we should wait for attach been called
         componentInstance = new Promise(resolve => {
-          events.on(String(subtreeId), () => resolve(subtreeInstances.get(subtreeId)));
+          events.filteredOnce(
+            id => id === String(subtreeId),
+            () => resolve(subtreeInstances.get(subtreeId)),
+          );
         });
       }
 

--- a/packages/core/src/reconciler/index.ts
+++ b/packages/core/src/reconciler/index.ts
@@ -1,9 +1,12 @@
 import ReactReconciler from 'react-reconciler';
+import { setBatchedUpdates } from '../utils/eventChannel';
 import { hostConfig } from './hostConfig';
 
 // FIXME: remove `as any` after fixing `hostConfigTypes.ts`
 export const reconciler = ReactReconciler(hostConfig as any);
 
 const { batchedUpdates } = reconciler;
+
+setBatchedUpdates(batchedUpdates);
 
 export { batchedUpdates };

--- a/packages/core/src/subtreeAttachEvents.ts
+++ b/packages/core/src/subtreeAttachEvents.ts
@@ -1,3 +1,3 @@
-import { EventEmitter } from 'events';
+import { EventChannel } from './utils/eventChannel';
 
-export default new EventEmitter();
+export default new EventChannel<string>();

--- a/packages/core/src/utils/eventChannel.ts
+++ b/packages/core/src/utils/eventChannel.ts
@@ -1,6 +1,8 @@
-import { batchedUpdates } from '../reconciler';
-
-type Callback<T, R> = T extends undefined ? (data?: T) => R : (data: T) => R;
+// `[T] extends [undefined]` is used to support union type in T
+// For more details see:
+// https://stackoverflow.com/questions/61926729/why-does-a-typescript-type-conditional-on-t-extends-undefined-with-t-instanti
+// https://github.com/microsoft/TypeScript/issues/37279#issuecomment-596192183
+type Callback<T, R> = [T] extends [undefined] ? (data?: T) => R : (data: T) => R;
 
 type TaskResult<R> = { success: false } | { success: true; result: R };
 
@@ -12,18 +14,11 @@ class EventChannelTask<T = undefined, R = void> {
   ) {}
 }
 
-/**
- * `batchedRun` is a simple wrapper of `batchedUpdates`
- * @param callback
- * @returns
- */
-function batchedRun<R>(callback: () => R): R {
-  let result: R;
-  batchedUpdates(() => {
-    result = callback();
-  });
-  return result!;
-}
+let batchedRun: <R>(callback: () => R) => R = callback => callback();
+
+export const setBatchedUpdates = (batchedUpdates: <R>(callback: () => R) => R) => {
+  batchedRun = batchedUpdates;
+};
 
 /**
  * `EventChannel` is a pub-sub event hub implementation.


### PR DESCRIPTION
This is the last part of https://github.com/airbnb/goji-js/pull/117 that replace all `events` with new `EventChannel` including

1. Universal hooks / useRenderedEffect
2. `Object.e` events ( component attached / de-attached )
3. `useRef`