### PR TITLE
Fix a typo in useVisibility

### DIFF
--- a/packages/core/src/lifecycles/universal/provider.tsx
+++ b/packages/core/src/lifecycles/universal/provider.tsx
@@ -35,14 +35,14 @@ export const UniversalHooksProvider = ({ children }: React.PropsWithChildren<{}>
   // useVisibility
   useImmediatelyEffect(
     () =>
-      eventProxyContext.lifecycleChannel.onLoad.on(() =>
+      eventProxyContext.lifecycleChannel.onShow.on(() =>
         universalLifecycleChannel.visibility.emit(true),
       ),
     [universalLifecycleChannel, eventProxyContext],
   );
   useImmediatelyEffect(
     () =>
-      eventProxyContext.lifecycleChannel.onLoad.on(() =>
+      eventProxyContext.lifecycleChannel.onHide.on(() =>
         universalLifecycleChannel.visibility.emit(false),
       ),
     [universalLifecycleChannel, eventProxyContext],


### PR DESCRIPTION
This typo cause `useVisibility` doesn't call when `onHide` or second `onShow`.