### PR TITLE
Refactor postcss-px2units to support PostCSS 8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,6 @@
     "postcss-loader": "^6.2.0",
     "postcss-nested": "^5.0.6",
     "postcss-preset-env": "^7.0.1",
-    "postcss-px2units": "^0.2.0",
     "postcss-reporter": "^7.0.4",
     "preprocess-loader": "^0.3.0",
     "resolve": "^1.19.0",

--- a/packages/cli/src/config/postcss.config.ts
+++ b/packages/cli/src/config/postcss.config.ts
@@ -15,7 +15,7 @@ module.exports = () => ({
       },
     }),
     // use postcss-px2units because some plugins, like postcss-calc, don't support `rpx` unit
-    require('postcss-px2units')({
+    require('./postcssPx2units')({
       multiple: 2,
       targetUnits: 'rpx',
     }),

--- a/packages/cli/src/config/postcssPx2units.ts
+++ b/packages/cli/src/config/postcssPx2units.ts
@@ -1,0 +1,52 @@
+// this plugin is inspired from https://github.com/yingye/postcss-px2units
+// and refactored to support PostCSS 8
+import type { PluginCreator } from 'postcss';
+
+interface Options {
+  divisor: number;
+  multiple: number;
+  decimalPlaces: number;
+  targetUnits: string;
+  comment: string;
+}
+
+const DEFAULT_OPTIONS: Options = {
+  divisor: 1,
+  multiple: 1,
+  decimalPlaces: 2,
+  targetUnits: 'rpx',
+  comment: 'no',
+};
+
+const postcssPx2units: PluginCreator<Partial<Options>> = (options = {}) => {
+  const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
+
+  const replacePx = (str: string) => {
+    if (!str) {
+      return '';
+    }
+
+    return str.replace(/\b(\d+(\.\d+)?)px\b/gi, (match, x) => {
+      const size = (x * mergedOptions.multiple) / mergedOptions.divisor;
+      return size % 1 === 0
+        ? size + mergedOptions.targetUnits
+        : size.toFixed(mergedOptions.decimalPlaces) + mergedOptions.targetUnits;
+    });
+  };
+
+  return {
+    postcssPlugin: 'postcss-px2units',
+    Declaration(declaration) {
+      const nextNode = declaration.next();
+      if (nextNode?.type === 'comment' && nextNode.text === mergedOptions.comment) {
+        nextNode.remove();
+      } else {
+        declaration.value = replacePx(declaration.value);
+      }
+    },
+  };
+};
+
+postcssPx2units.postcss = true;
+
+module.exports = postcssPx2units;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13403,14 +13403,6 @@ postcss-pseudo-class-any-link@^7.0.0:
   dependencies:
     postcss-selector-parser "^6"
 
-postcss-px2units@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-px2units/-/postcss-px2units-0.2.0.tgz#3793bf1a8ffe734b1093383277d54ac4cceabe4c"
-  integrity sha512-Jb3Z63DOh5bxYfxPnS2hDX5RAC1JSc9oBqroL/fN0kYqiNIw7p4plXGqtRKN62pkcfd5CfT6D9XIFFl8Ta3u0A==
-  dependencies:
-    object-assign "^4.1.1"
-    postcss "^6.0.19"
-
 postcss-reduce-initial@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz#7fd42ebea5e9c814609639e2c2e84ae270ba48df"
@@ -13553,15 +13545,6 @@ postcss-values-parser@6.0.1, postcss-values-parser@^6, postcss-values-parser@^6.
     color-name "^1.1.4"
     is-url-superb "^4.0.0"
     quote-unquote "^1.0.0"
-
-postcss@^6.0.19:
-  version "6.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
-  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.23, postcss@^7.0.27, postcss@^7.0.32:
   version "7.0.35"
@@ -15449,7 +15432,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
This PR forked the [postcss-px2units](https://github.com/yingye/postcss-px2units) and refactored it to support PostCSS 8.