### PR TITLE
Fix missing Buffer

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -287,8 +287,12 @@ export const getWebpackConfig = ({
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(nodeEnv),
       }),
+      // because Webpack 5 removed `node.*` support, we have to add them back manually
+      // from https://github.com/webpack/webpack/blob/3956274f1eada621e105208dcab4608883cdfdb2/lib/WebpackOptionsDefaulter.js#L168-L181
       new webpack.ProvidePlugin({
         process: nodeLibsBrowser.process,
+        Buffer: [nodeLibsBrowser.buffer, 'Buffer'],
+        // `global` will be shimmed by GojiShimPlugin and `setImmediate` is supported natively
       }),
       // show progress
       progress && new webpack.ProgressPlugin(),


### PR DESCRIPTION
Since we upgraded to Webpack 5, some global variables won't be shimmed automatically any more. So I use `DefinePlugin` to add them back.

Unfortunately I missed the `Buffer` in previous PR and cause code like `Buffer.from` fails to run.