### PR TITLE
Improve PostCSS performance

### DIFF
--- a/packages/cli/src/config/postcssConfig.ts
+++ b/packages/cli/src/config/postcssConfig.ts
@@ -1,5 +1,9 @@
 /* eslint-disable global-require */
-module.exports = () => ({
+
+// to improve PostCSS performance, we should always use `require(name)(options)` rather than `[name, options]`
+// also we should set `postcssOptions.config` to `false` to avoid loading any `postcss.config.js`
+// TODO: hope PostCSS could fix this issue https://github.com/csstools/postcss-preset-env/issues/232#issuecomment-992263741
+export default {
   plugins: [
     require('postcss-each')(),
     // TODO: `postcss-nesting` from `postcss-preset-env` output `:is` pseudo-class that
@@ -22,4 +26,4 @@ module.exports = () => ({
     require('cssnano')({ preset: 'default' }),
     require('postcss-reporter')({ clearReportedMessages: true }),
   ],
-});
+};

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -10,6 +10,7 @@ import resolve from 'resolve';
 import findCacheDir from 'find-cache-dir';
 import { version as babelCoreVersion } from '@babel/core/package.json';
 import { version as babelLoaderVersion } from 'babel-loader/package.json';
+import postcssConfig from './postcssConfig';
 import { preprocessLoader, getThreadLoader } from './loaders';
 
 const getSourceMap = (nodeEnv: string, target: GojiTarget): webpack.Configuration['devtool'] => {
@@ -215,7 +216,8 @@ export const getWebpackConfig = ({
               options: {
                 implementation: require.resolve('postcss'),
                 postcssOptions: {
-                  config: path.join(__dirname, 'postcss.config.js'),
+                  config: false,
+                  ...postcssConfig,
                 },
               },
             },
@@ -225,6 +227,7 @@ export const getWebpackConfig = ({
               options: {
                 implementation: require.resolve('postcss'),
                 postcssOptions: {
+                  config: false,
                   // eslint-disable-next-line global-require
                   plugins: [require('postcss-import')({})],
                 },
@@ -251,7 +254,8 @@ export const getWebpackConfig = ({
               options: {
                 implementation: require.resolve('postcss'),
                 postcssOptions: {
-                  config: path.join(__dirname, 'postcss.config.js'),
+                  config: false,
+                  ...postcssConfig,
                 },
               },
             },
@@ -261,6 +265,7 @@ export const getWebpackConfig = ({
               options: {
                 implementation: require.resolve('postcss'),
                 postcssOptions: {
+                  config: false,
                   // eslint-disable-next-line global-require
                   plugins: [require('postcss-import')({})],
                 },


### PR DESCRIPTION
[This issue](https://github.com/csstools/postcss-preset-env/issues/232) provides a performance improvement solution, that we can disable autoloading config to speed up `postcss-preset-env`.