### PR TITLE
Remove preprocess-loader

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,6 @@
     "postcss-nested": "^5.0.6",
     "postcss-preset-env": "^7.0.1",
     "postcss-reporter": "^7.0.4",
-    "preprocess-loader": "^0.3.0",
     "resolve": "^1.19.0",
     "terser-webpack-plugin": "^5.2.5",
     "thread-loader": "^3.0.4",

--- a/packages/cli/src/config/loaders.ts
+++ b/packages/cli/src/config/loaders.ts
@@ -7,31 +7,6 @@ export const getEnvForPreprocess = (nodeEnv: string, target: GojiTarget) => ({
   TARGET: target,
 });
 
-export const preprocessLoader = (
-  type: string,
-  nodeEnv: string,
-  target: GojiTarget,
-): webpack.RuleSetRule => {
-  const options = { ...getEnvForPreprocess(nodeEnv, target), ppOptions: { type } };
-
-  // here is a bug in preprocess-loader that remove the `options.ppOptions` unexpectly
-  // https://github.com/dearrrfish/preprocess-loader/issues/13
-  // we use Proxy to prevent delete action
-  const readonlyOptions = new Proxy(options, {
-    deleteProperty() {
-      // don't remove fields
-      return true;
-    },
-  });
-
-  const loaderConfig = {
-    loader: require.resolve('preprocess-loader'),
-    options: readonlyOptions,
-  };
-
-  return loaderConfig;
-};
-
 // `thread-loader` enable multi-thread compiling for Webpack
 const MOST_ECONOMICAL_WORKER_COUNT = 3;
 

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -11,7 +11,7 @@ import findCacheDir from 'find-cache-dir';
 import { version as babelCoreVersion } from '@babel/core/package.json';
 import { version as babelLoaderVersion } from 'babel-loader/package.json';
 import postcssConfig from './postcssConfig';
-import { preprocessLoader, getThreadLoader } from './loaders';
+import { getThreadLoader } from './loaders';
 
 const getSourceMap = (nodeEnv: string, target: GojiTarget): webpack.Configuration['devtool'] => {
   // enable source map in development mode
@@ -183,7 +183,6 @@ export const getWebpackConfig = ({
                 },
               },
             },
-            preprocessLoader('js', nodeEnv, target),
           ],
         },
         {
@@ -221,7 +220,6 @@ export const getWebpackConfig = ({
                 },
               },
             },
-            preprocessLoader('js', nodeEnv, target),
             {
               loader: require.resolve('postcss-loader'),
               options: {
@@ -259,7 +257,6 @@ export const getWebpackConfig = ({
                 },
               },
             },
-            preprocessLoader('js', nodeEnv, target),
             {
               loader: require.resolve('postcss-loader'),
               options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10781,7 +10781,7 @@ loader-utils@2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^1.0.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -13584,21 +13584,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
-
-preprocess-loader@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/preprocess-loader/-/preprocess-loader-0.3.0.tgz#21092bef9f75393f76cc20093d72d6e0229d8c78"
-  integrity sha512-dnHXb8y3tZljNWyuUe1Pps30eKg49GKSsSqwGJYDMaJqdNnC3xO4LtDZR9zYlLojnk1lOKk1I5dAMPkeD5g9rA==
-  dependencies:
-    loader-utils "^1.0.0"
-    preprocess "^3.0.2"
-
-preprocess@^3.0.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/preprocess/-/preprocess-3.2.0.tgz#36b3e2c52331fbc6fabb26d4fd5709304b7e3675"
-  integrity sha512-cO+Rf+Ose/eD+ze8Hxd9p9nS1xT8thYqv8owG/V8+IS/Remd7Z17SvaRK/oJxp08yaM8zb+QTckDKJUul2pk7g==
-  dependencies:
-    xregexp "3.1.0"
 
 prettier@^2.3.2:
   version "2.3.2"
@@ -16648,11 +16633,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xregexp@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-3.1.0.tgz#14d8461e0bdd38224bfee5039a0898fc42fcd336"
-  integrity sha1-FNhGHgvdOCJL/uUDmgiY/EL80zY=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR removed support of preprocess for these reasons:

1. Developers can use [`process.env.TARGET`](https://goji.js.org/docs/en/cross-platform#conditions-in-javascript-code) in JS / CSS-in-JS / JSX.
2. There is a [bug in preprocess-loader](https://github.com/airbnb/goji-js/blob/80696cfbe8324a6f39d7411f54bf0e7e3059a648/packages/cli/src/config/loaders.ts#L17-L25) and the bugfix cannot work with worker_threads based `thread-loader`.
3. `preprocess` cost extra building time.