### PR TITLE
Support Linaria new cacheProvider option

### DIFF
--- a/packages/beemo-dev/package.json
+++ b/packages/beemo-dev/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react-hooks": "^4.1.2",
     "jest": "^27.0.6",
     "lerna": "^4.0.0",
-    "linaria": "^2.1.0",
+    "linaria": "^2.3.0",
     "prettier": "^2.3.2"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "find-cache-dir": "^3.3.1",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^2.4.5",
+    "mkdirp": "^1.0.4",
     "node-libs-browser": "^2.2.1",
     "postcss": "^8.3.11",
     "postcss-calc": "^8.0.0",

--- a/packages/cli/src/config/linariaFileCache.ts
+++ b/packages/cli/src/config/linariaFileCache.ts
@@ -1,0 +1,50 @@
+/* eslint-disable import/no-import-module-exports */
+import findCacheDir from 'find-cache-dir';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import mkdirp from 'mkdirp';
+
+interface ICache {
+  get: (key: string) => Promise<string>;
+  set: (key: string, value: string) => Promise<void>;
+}
+
+const hashFileName = (name: string) => {
+  const hash = crypto.createHash('md4');
+  hash.update(name);
+  return hash.digest('hex');
+};
+
+class LinariaFileCache implements ICache {
+  private linariaCacheDir: string;
+
+  public constructor() {
+    const linariaCacheDir = findCacheDir({
+      name: `linaria-${process.env.NODE_ENV}-${process.env.GOJI_TARGET}`,
+      cwd: process.cwd(),
+    });
+    if (!linariaCacheDir) {
+      throw new Error('Get linaria cache dir failed');
+    }
+    mkdirp.sync(linariaCacheDir);
+    this.linariaCacheDir = linariaCacheDir;
+  }
+
+  public async get(key) {
+    return fs.promises.readFile(
+      path.join(this.linariaCacheDir, `${hashFileName(key)}.css`),
+      'utf8',
+    );
+  }
+
+  public async set(key, value) {
+    return fs.promises.writeFile(
+      path.join(this.linariaCacheDir, `${hashFileName(key)}.css`),
+      value,
+      'utf8',
+    );
+  }
+}
+
+module.exports = new LinariaFileCache();

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -7,7 +7,6 @@ import type { NonUndefined } from 'utility-types';
 import { GojiWebpackPluginOptions, GojiWebpackPlugin } from '@goji/webpack-plugin';
 import nodeLibsBrowser from 'node-libs-browser';
 import resolve from 'resolve';
-import findCacheDir from 'find-cache-dir';
 import { version as babelCoreVersion } from '@babel/core/package.json';
 import { version as babelLoaderVersion } from 'babel-loader/package.json';
 import postcssConfig from './postcssConfig';
@@ -171,12 +170,7 @@ export const getWebpackConfig = ({
               options: {
                 configFile: require.resolve('./linaria.config'),
                 sourceMap: true,
-                // Linaria defaults to use `.linaria-cache` folder rather than standard `node_modules/.cache`
-                // also we should use different folders based on `nodeEnv` and `target` to prevent wrong cache result
-                cacheDirectory: findCacheDir({
-                  name: `linaria-${nodeEnv}-${target}`,
-                  cwd: basedir,
-                }),
+                cacheProvider: require.resolve('./linariaFileCache'),
                 babelOptions: {
                   // always use internal babel.config.js file
                   configFile: require.resolve('./babel.config'),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,8 +38,11 @@ const main = async () => {
     console.error((error as Error).message);
     return;
   }
-  // re-patch NODE_ENV for `babel.config.ts`
+
+  // re-patch NODE_ENVs for config files
   process.env.NODE_ENV = cliConfig.production ? 'production' : 'development';
+  process.env.GOJI_TARGET = cliConfig.target;
+
   const gojiConfig = requireGojiConfig(basedir);
   // eslint-disable-next-line global-require
   const babelConfig = require('./config/babel.config');

--- a/packages/demo-todomvc-linaria/package.json
+++ b/packages/demo-todomvc-linaria/package.json
@@ -16,7 +16,7 @@
     "@goji/core": "^1.0.0-alpha.16",
     "classnames": "^2.2.6",
     "core-js": "^3.16.0",
-    "linaria": "^2.0.2",
+    "linaria": "^2.3.0",
     "react": "^17.0.2",
     "react-redux": "^7.2.5",
     "redux": "^4.1.1",

--- a/packages/demo-todomvc/package.json
+++ b/packages/demo-todomvc/package.json
@@ -17,7 +17,7 @@
     "@goji/macro": "^1.0.0-alpha.16",
     "classnames": "^2.2.6",
     "core-js": "^3.16.0",
-    "linaria": "^2.0.2",
+    "linaria": "^2.3.0",
     "react": "^17.0.2",
     "react-redux": "^7.2.5",
     "redux": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7669,14 +7669,6 @@ find-versions@^3.0.0:
   dependencies:
     semver-regex "^2.0.0"
 
-find-yarn-workspace-root@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
-  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
-  dependencies:
-    fs-extra "^4.0.3"
-    micromatch "^3.1.4"
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -7781,15 +7773,6 @@ fs-extra@^10.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
-
-fs-extra@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
-  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
 
 fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
@@ -10062,13 +10045,6 @@ json5@^2.1.1, json5@^2.1.2, json5@^2.2.0:
   dependencies:
     minimist "^1.2.5"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -10246,10 +10222,10 @@ lilconfig@^2.0.3:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
   integrity sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
 
-linaria@^2.0.2, linaria@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/linaria/-/linaria-2.1.0.tgz#2afd27d9dbcab08031c010bcc60eec2a174d50c7"
-  integrity sha512-dv6vuATZMYCDmnD5Ccgcqi2RUYfkfq/wE0hGUpyTW3khNAJqpiPWM7NVApCXxdD+mGg3WnD7fdkL+ndL9s8vtQ==
+linaria@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/linaria/-/linaria-2.3.0.tgz#bf6e309224aa4d2b6108f3616cc8665bba4cd20b"
+  integrity sha512-PwRbYk4Fu5BuSjse+2Nc6BQsx996L/OorFSZG8vEszEo0dd1ZnjXiRGpqR0lN4wVMTC55YntLNfraDFM8/xKRQ==
   dependencies:
     "@babel/generator" ">=7"
     "@babel/plugin-proposal-export-namespace-from" ">=7"
@@ -10263,7 +10239,6 @@ linaria@^2.0.2, linaria@^2.1.0:
     cosmiconfig "^5.1.0"
     debug "^4.1.1"
     enhanced-resolve "^4.1.0"
-    find-yarn-workspace-root "^1.2.1"
     glob "^7.1.3"
     loader-utils "^1.2.3"
     mkdirp "^0.5.1"
@@ -10855,7 +10830,7 @@ microevent.ts@~0.1.1:
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
 
-micromatch@^3.1.10, micromatch@^3.1.4:
+micromatch@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -15565,7 +15540,7 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
-universalify@^0.1.0, universalify@^0.1.2:
+universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==


### PR DESCRIPTION
Linaria support a new option `cacheProvider` since version 2.3 https://github.com/callstack/linaria/pull/884
We can use this option to make it compatible with `thread-loader`.