### PR TITLE
Stop using compiler.hooks.compile to improve build performance

### DIFF
--- a/packages/webpack-plugin/src/plugins/chunks/runtime.ts
+++ b/packages/webpack-plugin/src/plugins/chunks/runtime.ts
@@ -21,7 +21,11 @@ const getRuntimeNameCallback = (appConfig: AppConfig) => (entrypoint: WebpackEnt
 
 export class GojiRuntimeChunksWebpackPlugin extends GojiBasedWebpackPlugin {
   public apply(compiler: webpack.Compiler) {
-    compiler.hooks.compile.tap('GojiRuntimeChunksWebpackPlugin', () => {
+    const runtimeChunkInstance = new webpack.optimize.RuntimeChunkPlugin();
+    runtimeChunkInstance.apply(compiler);
+
+    // update options manually
+    compiler.hooks.thisCompilation.tap('GojiRuntimeChunksWebpackPlugin', () => {
       if (compiler.options.optimization?.runtimeChunk !== false) {
         throw new Error(
           'To enable `GojiRuntimeChunksWebpackPlugin`, the `optimization.runtimeChunk` in webpack config file must be `false`.',
@@ -31,11 +35,7 @@ export class GojiRuntimeChunksWebpackPlugin extends GojiBasedWebpackPlugin {
       if (!appConfig) {
         throw new Error('`appConfig` not found. This might be an internal error in GojiJS.');
       }
-      const name = getRuntimeNameCallback(appConfig);
-      // @ts-ignore
-      new webpack.optimize.RuntimeChunkPlugin({
-        name,
-      }).apply(compiler);
+      runtimeChunkInstance.options.name = getRuntimeNameCallback(appConfig);
     });
   }
 }

--- a/packages/webpack-plugin/src/plugins/nohoist.ts
+++ b/packages/webpack-plugin/src/plugins/nohoist.ts
@@ -11,50 +11,48 @@ const isNohoistTempFile = (filePath: string) => filePath.startsWith(`${NO_HOIST_
  */
 export class GojiNohoistWebpackPlugin extends GojiBasedWebpackPlugin {
   public apply(compiler: webpack.Compiler) {
-    compiler.hooks.compile.tap('GojiNohoistWebpackPlugin', () => {
-      compiler.hooks.thisCompilation.tap(
-        'GojiNohoistWebpackPlugin',
-        (compilation: webpack.Compilation) => {
-          compilation.hooks.afterOptimizeChunkModules.tap(
-            'GojiNohoistWebpackPlugin',
-            // @ts-ignore
-            (chunks: Set<webpack.Chunk>) => {
-              const { chunkGraph } = compilation;
-              // clean up useless chunks to prevent these temp files to be emitted
-              for (const chunk of chunks) {
-                if (!isNohoistTempFile(chunk.name)) {
-                  continue;
-                }
-                const nohoistTempFileName = path.posix.basename(chunk.name);
-                const chunkGroups = chunk.groupsIterable;
-                const modules = chunkGraph.getChunkModules(chunk);
-                // move chunk into each chunkGroups(sub packages)
-                for (const chunkGroup of chunkGroups) {
-                  const subPackageName = chunkGroup.options.name?.split('/')[0];
-                  const distNohoistFileName = `${subPackageName}/${NO_HOIST_PREFIX}${nohoistTempFileName}`;
-                  // fork the chunk to new chunk
-                  const newChunk: webpack.Chunk = compilation.addChunk(distNohoistFileName);
-                  newChunk.runtime = chunk.runtime;
-                  newChunk.idNameHints.add(distNohoistFileName);
-                  for (const module of modules) {
-                    chunkGraph.connectChunkAndModule(newChunk, module);
-                  }
-                  chunkGroup.replaceChunk(chunk, newChunk);
-                  chunk.removeGroup(chunkGroup);
-                  newChunk.addGroup(chunkGroup);
-                  chunks.add(newChunk);
-                }
-                // this line also clean up modules and groups
-                chunkGraph.disconnectChunk(chunk);
-                compilation.namedChunks.delete(chunk.name);
-                chunks.delete(chunk);
-                // TODO: remove in webpack 6
-                ChunkGraph.clearChunkGraphForChunk(chunk);
+    compiler.hooks.thisCompilation.tap(
+      'GojiNohoistWebpackPlugin',
+      (compilation: webpack.Compilation) => {
+        compilation.hooks.afterOptimizeChunkModules.tap(
+          'GojiNohoistWebpackPlugin',
+          // @ts-ignore
+          (chunks: Set<webpack.Chunk>) => {
+            const { chunkGraph } = compilation;
+            // clean up useless chunks to prevent these temp files to be emitted
+            for (const chunk of chunks) {
+              if (!isNohoistTempFile(chunk.name)) {
+                continue;
               }
-            },
-          );
-        },
-      );
-    });
+              const nohoistTempFileName = path.posix.basename(chunk.name);
+              const chunkGroups = chunk.groupsIterable;
+              const modules = chunkGraph.getChunkModules(chunk);
+              // move chunk into each chunkGroups(sub packages)
+              for (const chunkGroup of chunkGroups) {
+                const subPackageName = chunkGroup.options.name?.split('/')[0];
+                const distNohoistFileName = `${subPackageName}/${NO_HOIST_PREFIX}${nohoistTempFileName}`;
+                // fork the chunk to new chunk
+                const newChunk: webpack.Chunk = compilation.addChunk(distNohoistFileName);
+                newChunk.runtime = chunk.runtime;
+                newChunk.idNameHints.add(distNohoistFileName);
+                for (const module of modules) {
+                  chunkGraph.connectChunkAndModule(newChunk, module);
+                }
+                chunkGroup.replaceChunk(chunk, newChunk);
+                chunk.removeGroup(chunkGroup);
+                newChunk.addGroup(chunkGroup);
+                chunks.add(newChunk);
+              }
+              // this line also clean up modules and groups
+              chunkGraph.disconnectChunk(chunk);
+              compilation.namedChunks.delete(chunk.name);
+              chunks.delete(chunk);
+              // TODO: remove in webpack 6
+              ChunkGraph.clearChunkGraphForChunk(chunk);
+            }
+          },
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
Before:

`compiler.hooks.compile` => get `appConfig` => `compiler.hooks.thisCompilation`

After:

`compiler.hooks.thisCompilation` => get `appConfig`

In previous implement, I chose `compiler.hooks.compile` to ensure `appConfig` was already inited. But this hook runs each time Webpack re-build, which cause `compiler.hooks.thisCompilation` become larger and larger. 

This is the reason why as re-build happens, the bundling time also increases in Goji CLI watch mode.

![image](https://user-images.githubusercontent.com/1812118/151514729-389c1776-4f56-4367-aa3f-66a04c40e402.png)
