### PR TITLE
Support React Native's global variable `__DEV__`

### DIFF
--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -282,6 +282,9 @@ export const getWebpackConfig = ({
       }),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(nodeEnv),
+        // React Native specific global variable
+        // https://reactnative.dev/docs/javascript-environment#specific
+        __DEV__: JSON.stringify(nodeEnv !== 'production'),
       }),
       // because Webpack 5 removed `node.*` support, we have to add them back manually
       // from https://github.com/webpack/webpack/blob/3956274f1eada621e105208dcab4608883cdfdb2/lib/WebpackOptionsDefaulter.js#L168-L181


### PR DESCRIPTION
`__DEV__` is a [React Native's specific global variable](https://reactnative.dev/docs/javascript-environment#specific) that might be used in some 3rd-party `.native.js` files. 

For example, `@apollo/client`depends on this variable and try to [patch it within `global`](https://github.com/apollographql/apollo-client/blob/212b1e686359a3489b48d7e5d38a256312f81fde/src/utilities/globals/DEV.ts). But unfortunately Mini Program runtime doesn't have a valid `global` variable. So both the `__DEV__` and its patch fail to work.

<img width="648" alt="image" src="https://user-images.githubusercontent.com/1812118/160746703-dfb2de2d-4e17-4152-aa7f-47919cb02eaa.png">

In this PR I use `webpack.DefinePlugin` to replace all `__DEV__` usage in source code so the bug should be fixed.
