### PR TITLE
Remove default `libVersion` fields in `project.config.json`

### DIFF
--- a/packages/create-goji-app/templates/src/project.config.json
+++ b/packages/create-goji-app/templates/src/project.config.json
@@ -15,7 +15,6 @@
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",
-  "libVersion": "2.7.3",
   "appid": "testappid",
   "projectname": "<%= projectName %>",
   "debugOptions": {

--- a/packages/create-goji-app/templates/src/project.qq.json
+++ b/packages/create-goji-app/templates/src/project.qq.json
@@ -13,7 +13,6 @@
     "remoteDebugLogEnable": false,
     "prefetch": false
   },
-  "qqLibVersion": "1.21.0",
   "compileType": "miniprogram",
   "createTime": 1606913554830,
   "accessTime": 1606913554830,

--- a/packages/create-goji-app/templates/src/project.swan.json
+++ b/packages/create-goji-app/templates/src/project.swan.json
@@ -10,11 +10,5 @@
   "projectname": "test",
   "setting": {
     "urlCheck": false
-  },
-  "swan": {
-    "baiduboxapp": {
-      "extensionJsVersion": "100.14.255",
-      "swanJsVersion": "3.190.255-rc"
-    }
   }
 }

--- a/packages/demo-todomvc-linaria/src/project.config.json
+++ b/packages/demo-todomvc-linaria/src/project.config.json
@@ -15,7 +15,6 @@
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",
-  "libVersion": "2.7.3",
   "appid": "testappid",
   "projectname": "demo",
   "debugOptions": {

--- a/packages/demo-todomvc-linaria/src/project.qq.json
+++ b/packages/demo-todomvc-linaria/src/project.qq.json
@@ -13,7 +13,6 @@
     "remoteDebugLogEnable": false,
     "prefetch": false
   },
-  "qqLibVersion": "1.21.0",
   "compileType": "miniprogram",
   "createTime": 1606913554830,
   "accessTime": 1606913554830,

--- a/packages/demo-todomvc-linaria/src/project.swan.json
+++ b/packages/demo-todomvc-linaria/src/project.swan.json
@@ -10,11 +10,5 @@
   "projectname": "test",
   "setting": {
     "urlCheck": false
-  },
-  "swan": {
-    "baiduboxapp": {
-      "extensionJsVersion": "100.14.255",
-      "swanJsVersion": "3.190.255-rc"
-    }
   }
 }

--- a/packages/demo-todomvc/src/project.config.json
+++ b/packages/demo-todomvc/src/project.config.json
@@ -15,7 +15,6 @@
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",
-  "libVersion": "2.7.3",
   "appid": "testappid",
   "projectname": "demo",
   "debugOptions": {

--- a/packages/demo-todomvc/src/project.qq.json
+++ b/packages/demo-todomvc/src/project.qq.json
@@ -13,7 +13,6 @@
     "remoteDebugLogEnable": false,
     "prefetch": false
   },
-  "qqLibVersion": "1.21.0",
   "compileType": "miniprogram",
   "createTime": 1606913554830,
   "accessTime": 1606913554830,

--- a/packages/demo-todomvc/src/project.swan.json
+++ b/packages/demo-todomvc/src/project.swan.json
@@ -10,11 +10,5 @@
   "projectname": "test",
   "setting": {
     "urlCheck": false
-  },
-  "swan": {
-    "baiduboxapp": {
-      "extensionJsVersion": "100.14.255",
-      "swanJsVersion": "3.190.255-rc"
-    }
   }
 }

--- a/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.config.json
+++ b/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.config.json
@@ -15,7 +15,6 @@
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",
-  "libVersion": "2.7.3",
   "appid": "testappid",
   "projectname": "demo",
   "debugOptions": {

--- a/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.qq.json
+++ b/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.qq.json
@@ -13,7 +13,6 @@
     "remoteDebugLogEnable": false,
     "prefetch": false
   },
-  "qqLibVersion": "1.21.0",
   "compileType": "miniprogram",
   "createTime": 1606913554830,
   "accessTime": 1606913554830,

--- a/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.swan.json
+++ b/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.swan.json
@@ -10,11 +10,5 @@
   "projectname": "test",
   "setting": {
     "urlCheck": false
-  },
-  "swan": {
-    "baiduboxapp": {
-      "extensionJsVersion": "100.14.255",
-      "swanJsVersion": "3.190.255-rc"
-    }
   }
 }


### PR DESCRIPTION
The lib version field tells dev tool to use specific version of SDK. In most cases we prefer to the latest version.

So this PR removed these fields in GojiJS repo.

WeChat: `libVersion`
QQ: `qqLibVersion`
Baidu: `swan.baiduboxapp.swanJsVersion`