### PR TITLE
Enable wrapped input/textarea for baidu

### DIFF
--- a/packages/webpack-plugin/src/constants/components.ts
+++ b/packages/webpack-plugin/src/constants/components.ts
@@ -634,7 +634,7 @@ export const getBuiltInComponents = (target: GojiTarget): ComponentDesc[] =>
       },
       {
         name: 'input',
-        isWrapped: ['wechat', 'qq'].includes(target),
+        isWrapped: ['wechat', 'qq', 'baidu'].includes(target),
         props: {
           value: {
             required: true,
@@ -949,7 +949,7 @@ export const getBuiltInComponents = (target: GojiTarget): ComponentDesc[] =>
       },
       {
         name: 'textarea',
-        isWrapped: ['wechat', 'qq'].includes(target),
+        isWrapped: ['wechat', 'qq', 'baidu'].includes(target),
         props: {
           value: {
             required: false,


### PR DESCRIPTION
Wrapped components aim to resolve unexpected property change issues.

For example the `focus` property of `input` and `textarea` triggers a focus action each time when `this.setData` called. But in React world we expect it only happen when `focus` becomes `true` from `false`.

The wrapped component prevent useless `setData` by `observe` method to fix this issue. Because it's a custom component we need to test it carefully on each enabled platform.

<img width="290" alt="image" src="https://user-images.githubusercontent.com/1812118/163812740-31d7c36f-6ee2-4a4a-936c-26ee30750e76.png">
<img width="444" alt="image" src="https://user-images.githubusercontent.com/1812118/163812760-589fd6f5-8729-47c8-893c-0019535ce872.png">
