### PR TITLE
Replace all `@ts-ignore` with `@ts-expect-error`

### DIFF
--- a/packages/beemo-dev/configs/eslint.ts
+++ b/packages/beemo-dev/configs/eslint.ts
@@ -111,6 +111,15 @@ const config: ESLintConfig = {
     // https://github.com/typescript-eslint/typescript-eslint/issues/2477
     'no-undef': 'off',
     'no-tabs': 'error',
+    '@typescript-eslint/ban-ts-comment': [
+      'error',
+      {
+        'ts-expect-error': false,
+        'ts-ignore': true,
+        'ts-nocheck': false,
+        'ts-check': false,
+      },
+    ],
   },
 };
 

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -270,7 +270,7 @@ export const getWebpackConfig = ({
         },
       ],
     },
-    // @ts-ignore
+    // @ts-expect-error
     plugins: [
       new MiniCssExtractPlugin({
         filename: `[name].${CSS_FILE_EXT[target] ?? 'wxss'}`,

--- a/packages/core/src/__tests__/container.test.tsx
+++ b/packages/core/src/__tests__/container.test.tsx
@@ -22,17 +22,17 @@ describe('AdaptorInstance', () => {
     act(() => {
       render(<App />);
     });
-    // @ts-ignore
+    // @ts-expect-error
     expect(renderedCount).toBe(0);
-    // @ts-ignore
+    // @ts-expect-error
     expect(effectCount).toBe(0);
     act(() => {
       renderedSetCount(10);
       renderedSetCount(20);
     });
-    // @ts-ignore
+    // @ts-expect-error
     expect(renderedCount).toBe(20);
-    // @ts-ignore
+    // @ts-expect-error
     expect(effectCount).toBe(20);
   });
 });

--- a/packages/core/src/__tests__/helpers/adaptor.ts
+++ b/packages/core/src/__tests__/helpers/adaptor.ts
@@ -5,7 +5,6 @@ import { applyDiff } from '../../utils/diff';
 export class TestingAdaptorInstance extends AdaptorInstance {
   public data: any = {};
 
-  // @ts-ignore
   // eslint-disable-next-line
   public setData = (val: any) => {};
 

--- a/packages/core/src/__tests__/updates.test.tsx
+++ b/packages/core/src/__tests__/updates.test.tsx
@@ -8,7 +8,6 @@ describe('updates', () => {
   let adaptor: Adaptor;
 
   beforeAll(() => {
-    // @ts-ignore
     global.Page = function Page(options: WeChatPageConfig) {
       const instance: WeChatInstance = {
         setData(data) {
@@ -22,7 +21,7 @@ describe('updates', () => {
   });
 
   afterAll(() => {
-    // @ts-ignore
+    // @ts-expect-error
     delete global.Page;
   });
 
@@ -79,7 +78,7 @@ describe('updates', () => {
     adaptor.run(<TestComp />);
     diff = null;
 
-    // @ts-ignore
+    // @ts-expect-error
     updater(e => e);
     expect(diff).toEqual(null);
   });
@@ -101,7 +100,7 @@ describe('updates', () => {
     adaptor.run(<TestComp />);
     diff = null;
 
-    // @ts-ignore
+    // @ts-expect-error
     updater(false);
     expect(Object.keys(diff)).toEqual(['c[0].sid']);
   });

--- a/packages/core/src/adaptor/__tests__/wechat.test.tsx
+++ b/packages/core/src/adaptor/__tests__/wechat.test.tsx
@@ -5,7 +5,6 @@ import { WeChatAdaptor, WeChatPageConfig, WeChatInstance } from '../wechat';
 describe('WeChatAdaptor', () => {
   let data: any;
   beforeAll(() => {
-    // @ts-ignore
     global.Page = function Page(options: WeChatPageConfig) {
       const instance: WeChatInstance = {
         setData(newData) {
@@ -23,7 +22,7 @@ describe('WeChatAdaptor', () => {
   });
 
   afterAll(() => {
-    // @ts-ignore
+    // @ts-expect-error
     delete global.Page;
   });
 });

--- a/packages/core/src/adaptor/wechat.tsx
+++ b/packages/core/src/adaptor/wechat.tsx
@@ -197,14 +197,13 @@ export class WeChatAdaptor extends Adaptor {
     const { type } = this;
     if (type === 'page') {
       const pageConfig: WeChatPageConfig = pageLifecycles;
-      // @ts-ignore FIXME:
+      // @ts-expect-error FIXME:
       Page({
         ...pageConfig,
         ...eventHandler,
       });
     } else if (type === 'component') {
       const componentConfig: WeChatComponentConfig = {
-        // @ts-ignore FIXME:
         methods: { ...pageLifecycles, ...eventHandler },
       };
       Component(componentConfig);

--- a/packages/core/src/components/factoryComponents.ts
+++ b/packages/core/src/components/factoryComponents.ts
@@ -11,11 +11,9 @@ const factoryComponent = <
 ) => {
   const displayName = pascalCase(component);
   // FIXME: Not all components have `children`. We should fix the type later.
-  const comp = (props: P, ref: React.Ref<PublicInstance>) => 
-    // @ts-ignore
-     createElement(component, { ...props, ref })
-  ;
-
+  const comp = (props: P, ref: React.Ref<PublicInstance>) =>
+    // @ts-expect-error
+    createElement(component, { ...props, ref });
   const compWithRef = forwardRef<PublicInstance, P>(comp);
   compWithRef.displayName = displayName;
 

--- a/packages/core/src/lifecycles/universal/__tests__/hooks.test.tsx
+++ b/packages/core/src/lifecycles/universal/__tests__/hooks.test.tsx
@@ -71,7 +71,7 @@ describe('universal lifecycles', () => {
     // re-render the component with no UI changed
     wrapper.setManuallyResolvedUpdateCallback(false);
     renderedEffectCallback.mockClear();
-    // @ts-ignore
+    // @ts-expect-error
     forceUpdate();
     expect(renderedEffectCallback).toBeCalled();
   });
@@ -92,9 +92,9 @@ describe('universal lifecycles', () => {
     const wrapper = render(<Page />);
     wrapper.setManuallyResolvedUpdateCallback(true);
     // re-render the component
-    // @ts-ignore
+    // @ts-expect-error
     update();
-    // @ts-ignore
+    // @ts-expect-error
     update();
 
     renderedEffectCallback.mockClear();
@@ -207,7 +207,6 @@ describe('universal lifecycles', () => {
     let mockSetData = jest.fn();
     let update: () => void = () => {};
     let wrapper: RenderResult;
-    // @ts-ignore
     const originalPage = global.Page;
 
     beforeEach(() => {
@@ -233,7 +232,6 @@ describe('universal lifecycles', () => {
     });
 
     afterEach(() => {
-      // @ts-ignore
       global.Page = originalPage;
       setGojiBlockingMode(false);
     });

--- a/packages/core/src/patchGlobalObject.ts
+++ b/packages/core/src/patchGlobalObject.ts
@@ -18,5 +18,5 @@ class ObjectE {
   }
 }
 
-// @ts-ignore
+// @ts-expect-error
 Object.e = new ObjectE();

--- a/packages/core/src/reconciler/__tests__/instance.test.tsx
+++ b/packages/core/src/reconciler/__tests__/instance.test.tsx
@@ -52,7 +52,7 @@ describe('ElementInstance', () => {
 
   describe('getSubtreeId', () => {
     beforeAll(() => {
-      // @ts-ignore
+      // @ts-expect-error
       process.env.GOJI_WRAPPED_COMPONENTS = [];
     });
     const view = () =>
@@ -172,13 +172,13 @@ describe('ElementInstance', () => {
     expect(renderCount).toBe(1);
 
     // non batched
-    // @ts-ignore
+    // @ts-expect-error
     callback();
     act(() => {});
     expect(renderCount).toBe(3);
 
     // batched
-    // @ts-ignore
+    // @ts-expect-error
     batchedUpdates(callback);
     act(() => {});
     expect(renderCount).toBe(4);
@@ -255,7 +255,7 @@ describe('ElementInstance', () => {
       return textNodes.map(text => (text as TextNode).text);
     };
     expect(getTextList()).toEqual(['1', '2', '3']);
-    // @ts-ignore
+    // @ts-expect-error
     setItemsCallback([2, 1, 3]);
     expect(getTextList()).toEqual(['2', '1', '3']);
   });

--- a/packages/core/src/testUtils/act.ts
+++ b/packages/core/src/testUtils/act.ts
@@ -116,7 +116,7 @@ export function act(callback: () => Thenable<unknown> | void) {
           () => {
             if (
               actingUpdatesScopeDepth > 1 ||
-              // @ts-ignore
+              // @ts-expect-error
               (isSchedulerMocked === true && previousIsSomeRendererActing === true)
             ) {
               onDone();

--- a/packages/core/src/testUtils/forks.ts
+++ b/packages/core/src/testUtils/forks.ts
@@ -20,5 +20,5 @@ export const warningWithoutStack = (
 // only support Node yet
 export const enqueueTask = setImmediate;
 
-// @ts-ignore
+// @ts-expect-error
 export const ReactSharedInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED; // eslint-disable-line no-underscore-dangle

--- a/packages/core/src/utils/__tests__/styleAttrStringify.test.ts
+++ b/packages/core/src/utils/__tests__/styleAttrStringify.test.ts
@@ -4,7 +4,7 @@ describe('styleAttrStringify', () => {
   test('invalid values', () => {
     expect(styleAttrStringify(undefined)).toBe('');
     expect(styleAttrStringify({})).toBe('');
-    // @ts-ignore
+    // @ts-expect-error
     expect(styleAttrStringify({ width: null, height: undefined, top: 0 })).toBe('top:0;');
   });
 

--- a/packages/testing-library/src/utils/toJson.ts
+++ b/packages/testing-library/src/utils/toJson.ts
@@ -49,7 +49,7 @@ function realToJSON(inst, { omitProps = [] }: { omitProps?: Array<string> }) {
 }
 
 export function toJSON(node: ReactTestInstance, options = {}) {
-  // @ts-ignore
+  // @ts-expect-error
   // eslint-disable-next-line no-underscore-dangle
   const stateNode = node?._fiber?.stateNode;
   if (!stateNode) return null;

--- a/packages/webpack-plugin/src/forked/providePlugin.ts
+++ b/packages/webpack-plugin/src/forked/providePlugin.ts
@@ -25,7 +25,7 @@ class PatchedProvidePlugin {
    * @param {Record<string, string | string[]>} definitions the provided identifiers
    */
   constructor(definitions) {
-    // @ts-ignore
+    // @ts-expect-error
     this.definitions = definitions;
   }
 
@@ -35,7 +35,7 @@ class PatchedProvidePlugin {
    * @returns {void}
    */
   apply(compiler) {
-    // @ts-ignore
+    // @ts-expect-error
     const definitions = this.definitions;
     compiler.hooks.compilation.tap('ProvidePlugin', (compilation, { normalModuleFactory }) => {
       compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
@@ -46,7 +46,6 @@ class PatchedProvidePlugin {
           /* patch start */
           // Support `exclude` option
           let provideFile = definitions[name];
-          // @ts-ignore
           let excludeFiles = [];
           if (
             !Array.isArray(provideFile) &&
@@ -76,9 +75,7 @@ class PatchedProvidePlugin {
             /* patch start */
             // exclude files
             const currentFile = parser.state.current.request;
-            // @ts-ignore
             for (let i in excludeFiles) {
-              // @ts-ignore
               if (currentFile.match(excludeFiles[i])) {
                 return false;
               }

--- a/packages/webpack-plugin/src/forked/splitChunksPlugin.ts
+++ b/packages/webpack-plugin/src/forked/splitChunksPlugin.ts
@@ -91,7 +91,7 @@ export const normalizeCacheGroups = (cacheGroups, defaultSizeTypes) => {
       }
       if (typeof option === 'string' || option instanceof RegExp) {
         const source = createCacheGroupSource({}, key, defaultSizeTypes);
-        // @ts-ignore
+        // @ts-expect-error
         handlers.push((module, context, results) => {
           if (checkTest(option, module, context)) {
             results.push(source);
@@ -99,7 +99,7 @@ export const normalizeCacheGroups = (cacheGroups, defaultSizeTypes) => {
         });
       } else if (typeof option === 'function') {
         const cache = new WeakMap();
-        // @ts-ignore
+        // @ts-expect-error
         handlers.push((module, context, results) => {
           const result = option(module);
           if (result) {
@@ -118,7 +118,7 @@ export const normalizeCacheGroups = (cacheGroups, defaultSizeTypes) => {
         });
       } else {
         const source = createCacheGroupSource(option, key, defaultSizeTypes);
-        // @ts-ignore
+        // @ts-expect-error
         handlers.push((module, context, results) => {
           if (
             checkTest(option.test, module, context) &&
@@ -139,7 +139,7 @@ export const normalizeCacheGroups = (cacheGroups, defaultSizeTypes) => {
       /** @type {CacheGroupSource[]} */
       let results = [];
       for (const fn of handlers) {
-        // @ts-ignore
+        // @ts-expect-error
         fn(module, context, results);
       }
       return results;

--- a/packages/webpack-plugin/src/plugins/collectUsedComponents.ts
+++ b/packages/webpack-plugin/src/plugins/collectUsedComponents.ts
@@ -40,7 +40,7 @@ export class GojiCollectUsedComponentsWebpackPlugin extends GojiBasedWebpackPlug
             if (module.type.startsWith('javascript/')) {
               for (const dependency of module.dependencies) {
                 // only process `@goji/core`
-                // @ts-ignore
+                // @ts-expect-error
                 if (dependency.request !== GOJI_CORE_PACKAGE_NAME) {
                   continue;
                 }
@@ -48,7 +48,7 @@ export class GojiCollectUsedComponentsWebpackPlugin extends GojiBasedWebpackPlug
                   case COMMON_JS_REQUIRE_DEPENDENCY_TYPE: {
                     compilation.warnings.push(
                       new WebpackError(
-                        // @ts-ignore
+                        // @ts-expect-error
                         `[GojiCollectUsedComponentsWebpackPlugin] \nGojiJS strongly recommend to use ES module in ${module.resource} otherwise the bridge file size optimization was disabled`,
                       ),
                     );
@@ -57,17 +57,17 @@ export class GojiCollectUsedComponentsWebpackPlugin extends GojiBasedWebpackPlug
                   case HARMONY_IMPORT_SPECIFIER_DEPENDENCY_TYPE: {
                     // `dependency.ids` would be `[]` if this is a namespace import, which means `import * as xx from 'yy'`
                     // see https://github.com/webpack/webpack/blob/a3bef27457d8936f81525beaa633eb1931382dc0/lib/javascript/JavascriptParser.js#L1750
-                    // @ts-ignore
+                    // @ts-expect-error
                     if (!dependency.ids.length) {
                       compilation.warnings.push(
                         new WebpackError(
-                          // @ts-ignore
+                          // @ts-expect-error
                           `[GojiCollectUsedComponentsWebpackPlugin] \nShould not use \`import * as ${dependency.name} from '@goji/core'\` in ${module.resource}`,
                         ),
                       );
                       return undefined;
                     }
-                    // @ts-ignore
+                    // @ts-expect-error
                     for (const id of dependency.ids) {
                       dependencyNamesSet.add(id);
                     }

--- a/packages/webpack-plugin/src/plugins/nohoist.ts
+++ b/packages/webpack-plugin/src/plugins/nohoist.ts
@@ -16,7 +16,7 @@ export class GojiNohoistWebpackPlugin extends GojiBasedWebpackPlugin {
       (compilation: webpack.Compilation) => {
         compilation.hooks.afterOptimizeChunkModules.tap(
           'GojiNohoistWebpackPlugin',
-          // @ts-ignore
+          // @ts-expect-error
           (chunks: Set<webpack.Chunk>) => {
             const { chunkGraph } = compilation;
             // clean up useless chunks to prevent these temp files to be emitted

--- a/packages/webpack-plugin/src/plugins/shim/global.ts
+++ b/packages/webpack-plugin/src/plugins/shim/global.ts
@@ -40,11 +40,11 @@ const unpatchedGlobalVariables = {
 
   // error objects
   Error: typeof Error === 'undefined' ? undefined : Error,
-  // @ts-ignore
+  // @ts-expect-error
   // eslint-disable-next-line no-undef
   AggregateError: typeof AggregateError === 'undefined' ? undefined : AggregateError,
   EvalError: typeof EvalError === 'undefined' ? undefined : EvalError,
-  // @ts-ignore
+  // @ts-expect-error
   // eslint-disable-next-line no-undef
   InternalError: typeof InternalError === 'undefined' ? undefined : InternalError,
   RangeError: typeof RangeError === 'undefined' ? undefined : RangeError,

--- a/packages/webpack-plugin/src/plugins/shim/patches/__tests__/array.test.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/__tests__/array.test.ts
@@ -54,14 +54,14 @@ describe('patch `Array`', () => {
   });
 
   it('patch prototype method', () => {
-    // @ts-ignore
+    // @ts-expect-error
     PatchedArray.prototype.myMethod = function myMethod() {
       return `${this.length} test`;
     };
     const array = new PatchedArray(3);
-    // @ts-ignore
+    // @ts-expect-error
     expect(typeof array.myMethod).toBe('function');
-    // @ts-ignore
+    // @ts-expect-error
     expect(array.myMethod()).toBe('3 test');
   });
 

--- a/packages/webpack-plugin/src/plugins/shim/patches/__tests__/function.test.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/__tests__/function.test.ts
@@ -34,7 +34,6 @@ describe('patch `Function`', () => {
     const fnPatched = PatchedFunction('global.__shouldNotBeSet = true');
     expect(fnPatched).toBeTruthy();
     fnPatched();
-    // @ts-ignore
     // eslint-disable-next-line no-underscore-dangle
     expect(global.__shouldNotBeSet).not.toBe(true);
   });
@@ -72,12 +71,12 @@ describe('patch `Function`', () => {
   });
 
   it('patch prototype method', () => {
-    // @ts-ignore
+    // @ts-expect-error
     PatchedFunction.prototype.myMethod = () => true;
     const promise = new PatchedFunction('return this');
-    // @ts-ignore
+    // @ts-expect-error
     expect(typeof promise.myMethod).toBe('function');
-    // @ts-ignore
+    // @ts-expect-error
     expect(promise.myMethod()).toBe(true);
   });
 

--- a/packages/webpack-plugin/src/plugins/shim/patches/__tests__/getCurrentPages.test.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/__tests__/getCurrentPages.test.ts
@@ -13,14 +13,13 @@ describe('patch `getCurrentPages`', () => {
   Object.setPrototypeOf(mockPage, mockProto);
 
   beforeAll(() => {
-    // @ts-ignore
     global.getCurrentPages = () => [mockPage];
     // eslint-disable-next-line global-require
     patchedGetCurrentPages = require('../getCurrentPages');
   });
 
   afterAll(() => {
-    // @ts-ignore
+    // @ts-expect-error
     delete global.getCurrentPages;
   });
 

--- a/packages/webpack-plugin/src/plugins/shim/patches/__tests__/promise.test.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/__tests__/promise.test.ts
@@ -47,12 +47,12 @@ describe('patch `Promise`', () => {
   });
 
   it('patch prototype method', () => {
-    // @ts-ignore
+    // @ts-expect-error
     PatchedPromise.prototype.myMethod = () => true;
     const promise = new PatchedPromise(executor);
-    // @ts-ignore
+    // @ts-expect-error
     expect(typeof promise.myMethod).toBe('function');
-    // @ts-ignore
+    // @ts-expect-error
     expect(promise.myMethod()).toBe(true);
   });
 

--- a/packages/webpack-plugin/src/plugins/shim/patches/__tests__/string.test.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/__tests__/string.test.ts
@@ -47,14 +47,14 @@ describe('patch `String`', () => {
   });
 
   it('patch prototype method', () => {
-    // @ts-ignore
+    // @ts-expect-error
     PatchedString.prototype.myMethod = function myMethod() {
       return `${this} test`;
     };
     const string = new PatchedString(value);
-    // @ts-ignore
+    // @ts-expect-error
     expect(typeof string.myMethod).toBe('function');
-    // @ts-ignore
+    // @ts-expect-error
     expect(string.myMethod()).toBe('hello, world! test');
   });
 

--- a/packages/webpack-plugin/src/plugins/shim/patches/string.ts
+++ b/packages/webpack-plugin/src/plugins/shim/patches/string.ts
@@ -7,7 +7,7 @@ const patchString = () => {
   const PatchedString = function String(this: any, value: any): string {
     let instance: string;
     if (this instanceof PatchedString || this instanceof OriginalString) {
-      // @ts-ignore
+      // @ts-expect-error
       instance = new OriginalString(value);
     } else {
       instance = OriginalString(value);

--- a/packages/webpack-plugin/src/templates/helpers/t.ts
+++ b/packages/webpack-plugin/src/templates/helpers/t.ts
@@ -4,7 +4,7 @@ import {
   createTag,
   inlineArrayTransformer,
   splitStringTransformer,
-  // @ts-ignore
+  // @ts-expect-error
   removeNonPrintingValuesTransformer,
   trimResultTransformer,
 } from 'common-tags';
@@ -27,7 +27,7 @@ const trimEndSubstitutions = (): TemplateTransformer => ({
   },
 });
 
-// @ts-ignore
+// @ts-expect-error
 export const t = createTag(
   // support function substitutions: ${() => 'hi'}
   runFunctionSubstitutions(),

--- a/packages/webpack-plugin/src/utils/loadConfig.ts
+++ b/packages/webpack-plugin/src/utils/loadConfig.ts
@@ -8,10 +8,10 @@ import { safeUrlToRequest } from './path';
 export const exec = (code: string, filename: string, context: string) => {
   /* eslint-disable no-underscore-dangle */
   const module = new Module(filename, undefined);
-  // @ts-ignore
+  // @ts-expect-error
   module.paths = Module._nodeModulePaths(context);
   module.filename = filename;
-  // @ts-ignore
+  // @ts-expect-error
   module._compile(code, filename);
 
   return module.exports;


### PR DESCRIPTION
This PR also enabled an ESLint to rule to deny `@ts-ignore` usage.