### PR TITLE
Refactor ComponentDesc

### DIFF
--- a/packages/webpack-plugin/src/constants/components.ts
+++ b/packages/webpack-plugin/src/constants/components.ts
@@ -54,7 +54,6 @@ export type ComponentDesc = {
   name: string;
   props: Record<string, ComponentPropDesc>;
   events: string[];
-  nativePath?: string;
   isLeaf?: boolean;
   isWrapped?: boolean;
 };

--- a/packages/webpack-plugin/src/templates/commons/__tests__/nativeComponentJson.test.ts
+++ b/packages/webpack-plugin/src/templates/commons/__tests__/nativeComponentJson.test.ts
@@ -1,5 +1,6 @@
 import { renderTemplate } from '../..';
 import { ComponentDesc } from '../../../constants/components';
+import { PluginComponentDesc } from '../../../utils/pluginComponent';
 import { nativeComponentJson } from '../nativeComponentJson';
 
 describe('nativeComponentJson', () => {
@@ -18,28 +19,53 @@ describe('nativeComponentJson', () => {
       isWrapped: true,
     },
   ];
+  const pluginComponents: PluginComponentDesc[] = [
+    {
+      name: 'swan-sitemap-list',
+      props: {
+        x: {
+          type: 'Number',
+        },
+        y: {
+          type: 'Number',
+        },
+      },
+      nativePath: 'dynamicLib://swan-sitemap-lib/swan-sitemap-list',
+    },
+  ];
 
   test('leaf component', () => {
     const json = JSON.parse(
       renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
-        nativeComponentJson({ isLeaf: true, relativePathToBridge: '.', components }),
+        nativeComponentJson({
+          isComponent: true,
+          isLeaf: true,
+          relativePathToBridge: '.',
+          components,
+          pluginComponents,
+        }),
       ),
     );
     expect(json.usingComponents).toEqual({});
-    // expect(json.usingComponents['goji-view']).toBeTruthy();
   });
 
   test('non-leaf component', () => {
     const json = JSON.parse(
       renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
-        nativeComponentJson({ isLeaf: false, relativePathToBridge: '.', components }),
+        nativeComponentJson({
+          isComponent: true,
+          isLeaf: false,
+          relativePathToBridge: '.',
+          components,
+          pluginComponents,
+        }),
       ),
     );
     expect(json.usingComponents).not.toEqual({});
     expect(json.usingComponents['goji-view']).toBe('./components/view');
     expect(json.usingComponents['goji-subtree']).toBe('./subtree');
+    expect(json.usingComponents['swan-sitemap-list']).toBe(
+      'dynamicLib://swan-sitemap-lib/swan-sitemap-list',
+    );
   });
-
-  // FIXME: support plugin in subtree/wrapped
-  test.skip('plugin native path', () => {});
 });

--- a/packages/webpack-plugin/src/templates/commons/__tests__/wxmlElement.test.ts
+++ b/packages/webpack-plugin/src/templates/commons/__tests__/wxmlElement.test.ts
@@ -19,7 +19,7 @@ describe('getConditionFromSidOrName', () => {
   test('has simplify id', () => {
     expect(
       renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
-        getConditionFromSidOrName({ name: 'view', sid: 100 }),
+        getConditionFromSidOrName({ name: 'view', simplifiedId: 100 }),
       ),
     ).toBe('meta.simplifiedId === 100');
   });

--- a/packages/webpack-plugin/src/templates/commons/nativeComponentJson.ts
+++ b/packages/webpack-plugin/src/templates/commons/nativeComponentJson.ts
@@ -2,26 +2,44 @@ import { ComponentDesc } from '../../constants/components';
 import { getComponentTagName } from './wxmlElement';
 import { getFeatures } from '../../constants/features';
 import { CommonContext } from '../helpers/context';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
 
+/**
+ * Generate the JSON file of native component.
+ * @param isComponent Whether this JSON file is for a component, or a page.
+ * @param isLeaf Whether to render `usingComponents`.
+ * @param relativePathToBridge The path to bridge folder.
+ * @param components Component list.
+ * @param pluginComponent Plugin component list.
+ */
 export const nativeComponentJson = ({
+  isComponent,
   isLeaf,
   relativePathToBridge,
   components,
+  pluginComponents,
 }: {
+  isComponent: boolean;
   isLeaf: boolean;
   relativePathToBridge: string;
   components: ComponentDesc[];
+  pluginComponents: PluginComponentDesc[];
 }) => {
   const features = getFeatures(CommonContext.read().target);
 
   const usingComponents: Record<string, string> = {};
   if (!isLeaf) {
+    // add wrapped components
     for (const component of components) {
       if (component.isWrapped) {
         usingComponents[
           getComponentTagName({ isWrapped: component.isWrapped, name: component.name })
         ] = `${relativePathToBridge}/components/${component.name}`;
       }
+    }
+    // add plugin components
+    for (const component of pluginComponents) {
+      usingComponents[component.name] = component.nativePath;
     }
     if (features.useSubtree) {
       usingComponents[
@@ -32,7 +50,8 @@ export const nativeComponentJson = ({
 
   return JSON.stringify(
     {
-      component: true,
+      // use `undefined` to skip this field
+      component: isComponent || undefined,
       usingComponents,
     },
     null,

--- a/packages/webpack-plugin/src/templates/commons/wxmlElement.ts
+++ b/packages/webpack-plugin/src/templates/commons/wxmlElement.ts
@@ -3,12 +3,18 @@ import camelCase from 'lodash/camelCase';
 import { getIds } from '../helpers/ids';
 import { t } from '../helpers/t';
 
-export const getConditionFromSidOrName = ({ sid, name }: { sid?: number; name: string }) => {
+export const getConditionFromSidOrName = ({
+  simplifiedId,
+  name,
+}: {
+  simplifiedId?: number;
+  name: string;
+}) => {
   const ids = getIds();
 
-  return sid === undefined
+  return simplifiedId === undefined
     ? t`${ids.meta}.${ids.type} === '${name}'`
-    : t`${ids.meta}.${ids.simplifiedId} === ${sid}`;
+    : t`${ids.meta}.${ids.simplifiedId} === ${simplifiedId}`;
 };
 
 export const getComponentTagName = ({ isWrapped, name }: { isWrapped?: boolean; name: string }) =>

--- a/packages/webpack-plugin/src/templates/components/__tests__/components.wxml.test.tsx
+++ b/packages/webpack-plugin/src/templates/components/__tests__/components.wxml.test.tsx
@@ -1,5 +1,5 @@
 import { renderTemplate } from '../..';
-import { ComponentRenderData } from '../../../utils/components';
+import { AllComponentDesc } from '../../../utils/components';
 import { componentAttribute, componentAttributes } from '../components.wxml';
 
 describe('componentAttribute', () => {
@@ -38,10 +38,10 @@ describe('componentAttribute', () => {
 
 describe('componentAttributes', () => {
   test('simple component', () => {
-    const component: ComponentRenderData = {
+    const component: AllComponentDesc = {
       name: 'view',
       events: [],
-      attributes: [],
+      props: {},
     };
 
     expect(componentAttributes({ component })).toEqual(
@@ -55,11 +55,11 @@ describe('componentAttributes', () => {
   });
 
   test('wrapped component', () => {
-    const component: ComponentRenderData = {
+    const component: AllComponentDesc = {
       name: 'view',
       isWrapped: true,
       events: [],
-      attributes: [],
+      props: {},
     };
 
     expect(
@@ -78,25 +78,31 @@ describe('componentAttributes', () => {
   });
 
   test('events', () => {
-    const component: ComponentRenderData = {
+    const component: AllComponentDesc = {
       name: 'view',
       events: ['tap', 'change'],
-      attributes: [],
+      props: {},
     };
 
     expect(
       renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
         componentAttributes({ component }),
       ),
-    ).toEqual(expect.arrayContaining(['tap="e"', 'change="e"']));
+    ).toEqual(expect.arrayContaining(['bindtap="e"', 'bindchange="e"']));
+
+    expect(
+      renderTemplate({ target: 'alipay', nodeEnv: 'development' }, () =>
+        componentAttributes({ component }),
+      ),
+    ).toEqual(expect.arrayContaining(['onTap="e"', 'onChange="e"']));
   });
 
   test('events in wrapped component', () => {
-    const component: ComponentRenderData = {
+    const component: AllComponentDesc = {
       name: 'view',
       isWrapped: true,
       events: ['tap', 'change'],
-      attributes: [],
+      props: {},
     };
 
     expect(
@@ -107,20 +113,19 @@ describe('componentAttributes', () => {
   });
 
   test('attributes', () => {
-    const component: ComponentRenderData = {
+    const component: AllComponentDesc = {
       name: 'view',
       events: [],
-      attributes: [
-        {
-          name: 'scale-min',
-          value: 'scaleMin',
+
+      props: {
+        'scale-min': {
+          type: 'String',
         },
-        {
-          name: 'scale-max',
-          value: 'scaleMax',
-          fallback: 100,
+        'scale-max': {
+          type: 'Number',
+          defaultValue: 100,
         },
-      ],
+      },
     };
 
     expect(

--- a/packages/webpack-plugin/src/templates/components/components.wxml/index.tsx
+++ b/packages/webpack-plugin/src/templates/components/components.wxml/index.tsx
@@ -1,5 +1,14 @@
-import { ComponentRenderData } from '../../../utils/components';
-import { element, getComponentTagName, getConditionFromSidOrName } from '../../commons/wxmlElement';
+import { GojiTarget } from '@goji/core';
+import camelCase from 'lodash/camelCase';
+import { ComponentDesc } from '../../../constants/components';
+import { AllComponentDesc, isWrapped, SimplifiedComponentDesc } from '../../../utils/components';
+import { PluginComponentDesc } from '../../../utils/pluginComponent';
+import {
+  element,
+  getComponentTagName,
+  getConditionFromSidOrName,
+  getEventName,
+} from '../../commons/wxmlElement';
 import { CommonContext } from '../../helpers/context';
 import { getIds } from '../../helpers/ids';
 import { t } from '../../helpers/t';
@@ -27,10 +36,41 @@ export const componentAttribute = ({
   }
 };
 
-export const componentAttributes = ({ component }: { component: ComponentRenderData }) => {
+// FIXME: Baidu has a bug that we have to add default value for input's password
+// swanide://fragment/543afd77cf5244addd3f67158948c8b71571973909208
+const forceRenderFallback = (target: GojiTarget, componentName: string, propsName: string) => {
+  if (target === 'baidu' && componentName === 'input' && propsName === 'password') {
+    return true;
+  }
+  return false;
+};
+
+const mapComponentPropsToAttributes = (component: AllComponentDesc) => {
+  const { target } = CommonContext.read();
+  return Object.entries(component.props).map(([name, desc]) => {
+    if (
+      (!desc.required && desc.defaultValue) ||
+      forceRenderFallback(target, component.name, name)
+    ) {
+      return {
+        name,
+        value: camelCase(name),
+        fallback: desc.defaultValue,
+      };
+    }
+
+    return {
+      name,
+      value: camelCase(name),
+    };
+  });
+};
+
+export const componentAttributes = ({ component }: { component: AllComponentDesc }) => {
   const ids = getIds();
+  const { target } = CommonContext.read();
   const propsArray: Array<string> = [];
-  if (component.isWrapped) {
+  if (isWrapped(component)) {
     if (!component.isLeaf) {
       propsArray.push(`nodes="{{${ids.meta}.${ids.children}}}"`);
     }
@@ -49,10 +89,10 @@ export const componentAttributes = ({ component }: { component: ComponentRenderD
       componentAttribute({ name: 'style', value: 'style', fallback: '' }),
     );
   }
-  propsArray.push(...component.attributes.map(attribute => componentAttribute(attribute)));
-  if (!component.isWrapped) {
+  propsArray.push(...mapComponentPropsToAttributes(component).map(componentAttribute));
+  if (!isWrapped(component) && 'events' in component) {
     // wrapped components will handle event inside themselves
-    propsArray.push(...component.events.map(event => t`${event}="e"`));
+    propsArray.push(...component.events.map(event => t`${getEventName({ target, event })}="e"`));
   }
 
   return propsArray;
@@ -63,7 +103,7 @@ export const componentItem = ({
   depth,
   componentsDepth,
 }: {
-  component: ComponentRenderData;
+  component: AllComponentDesc;
   depth: number;
   componentsDepth: number;
 }) => {
@@ -72,7 +112,7 @@ export const componentItem = ({
   const tagName = getComponentTagName(component);
   const attributes = componentAttributes({ component });
   const children = ((): string => {
-    if (component.isWrapped || component.isLeaf) {
+    if (isWrapped(component) || component.isLeaf) {
       return '';
     }
     if (inlineChildrenRender) {
@@ -99,11 +139,15 @@ export const componentWxml = ({
   depth,
   useFlattenSwiper,
   components,
+  simplifiedComponents,
+  pluginComponents,
   componentsDepth,
 }: {
   depth: number;
   useFlattenSwiper: boolean;
-  components: Array<ComponentRenderData>;
+  components: Array<ComponentDesc>;
+  simplifiedComponents: Array<SimplifiedComponentDesc>;
+  pluginComponents: Array<PluginComponentDesc>;
   componentsDepth: number;
 }) => {
   const ids = getIds();
@@ -123,7 +167,12 @@ export const componentWxml = ({
       </block>
       ${useFlattenText && FlattenText()}
       ${useFlattenSwiper && FlattenSwiper()}
-      ${components.map(component => componentItem({ component, componentsDepth, depth }))}
+      ${
+        // render simplified components first for better performance
+        [...simplifiedComponents, ...components, ...pluginComponents]
+          .filter(_ => !_.isLeaf)
+          .map(component => componentItem({ component, componentsDepth, depth }))
+      }
       <block wx:else>
         <include src="./leaf-components.wxml" />
       </block>

--- a/packages/webpack-plugin/src/templates/components/item.json.ts
+++ b/packages/webpack-plugin/src/templates/components/item.json.ts
@@ -1,37 +1,20 @@
 import { ComponentDesc } from '../../constants/components';
-import { getFeatures } from '../../constants/features';
-import { getComponentTagName } from '../commons/wxmlElement';
-import { CommonContext } from '../helpers/context';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
+import { nativeComponentJson } from '../commons/nativeComponentJson';
 
 export const itemJson = ({
   relativePathToBridge,
   components,
+  pluginComponents,
 }: {
   relativePathToBridge: string;
   components: ComponentDesc[];
-}) => {
-  const features = getFeatures(CommonContext.read().target);
-  const usingComponents: Record<string, string> = {};
-  for (const component of components) {
-    if (component.isWrapped) {
-      usingComponents[
-        getComponentTagName({ isWrapped: component.isWrapped, name: component.name })
-      ] = `${relativePathToBridge}/components/${component.name}`;
-    } else if (component.nativePath) {
-      usingComponents[component.name] = component.nativePath;
-    }
-  }
-  if (features.useSubtree) {
-    usingComponents[
-      getComponentTagName({ isWrapped: true, name: 'subtree' })
-    ] = `${relativePathToBridge}/subtree`;
-  }
-
-  return JSON.stringify(
-    {
-      usingComponents,
-    },
-    null,
-    2,
-  );
-};
+  pluginComponents: PluginComponentDesc[];
+}) =>
+  nativeComponentJson({
+    isComponent: false,
+    isLeaf: false,
+    relativePathToBridge,
+    components,
+    pluginComponents,
+  });

--- a/packages/webpack-plugin/src/templates/components/leaf-components.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/leaf-components.wxml.ts
@@ -1,16 +1,31 @@
-import { ComponentRenderData } from '../../utils/components';
+import { ComponentDesc } from '../../constants/components';
+import { SimplifiedComponentDesc } from '../../utils/components';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
 import { t } from '../helpers/t';
 import { componentItem } from './components.wxml';
 
-export const leafComponentWxml = ({ components }: { components: ComponentRenderData[] }) => t`
+export const leafComponentWxml = ({
+  components,
+  simplifiedComponents,
+  pluginComponents,
+}: {
+  components: Array<ComponentDesc>;
+  simplifiedComponents: Array<SimplifiedComponentDesc>;
+  pluginComponents: Array<PluginComponentDesc>;
+}) => t`
     <block wx:if="{{false}}"></block>
-    ${components.map(component =>
-      componentItem({
-        component,
-        // FIXME: remove this filed
-        depth: -1,
-        // FIXME: remove this filed
-        componentsDepth: -1,
-      }),
-    )}
+    ${
+      // render simplified components first for better performance
+      [...simplifiedComponents, ...components, ...pluginComponents]
+        .filter(_ => _.isLeaf)
+        .map(component =>
+          componentItem({
+            component,
+            // FIXME: remove this filed
+            depth: -1,
+            // FIXME: remove this filed
+            componentsDepth: -1,
+          }),
+        )
+    }
   `;

--- a/packages/webpack-plugin/src/templates/components/subtree.json.ts
+++ b/packages/webpack-plugin/src/templates/components/subtree.json.ts
@@ -1,10 +1,20 @@
 import { ComponentDesc } from '../../constants/components';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
 import { nativeComponentJson } from '../commons/nativeComponentJson';
 
 export const subtreeJson = ({
   relativePathToBridge,
   components,
+  pluginComponents,
 }: {
   relativePathToBridge: string;
   components: ComponentDesc[];
-}) => nativeComponentJson({ relativePathToBridge, components, isLeaf: false });
+  pluginComponents: PluginComponentDesc[];
+}) =>
+  nativeComponentJson({
+    isComponent: true,
+    isLeaf: false,
+    relativePathToBridge,
+    components,
+    pluginComponents,
+  });

--- a/packages/webpack-plugin/src/templates/components/wrapped.js.ts
+++ b/packages/webpack-plugin/src/templates/components/wrapped.js.ts
@@ -1,5 +1,6 @@
 import camelCase from 'lodash/camelCase';
 import { ComponentDesc, ComponentPropDesc } from '../../constants/components';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
 import { WRAPPED_CONFIGS, DEFAULT_WRAPPED_CONFIG, WrappedConfig } from '../commons/wrapped';
 import { t } from '../helpers/t';
 
@@ -15,7 +16,7 @@ export const processWrappedProps = ({
   component,
   config,
 }: {
-  component: ComponentDesc;
+  component: ComponentDesc | PluginComponentDesc;
   config: WrappedConfig;
 }) => {
   const data: Array<string> = [];
@@ -87,21 +88,23 @@ export const processWrappedEvents = ({
   component,
   config,
 }: {
-  component: ComponentDesc;
+  component: ComponentDesc | PluginComponentDesc;
   config: WrappedConfig;
 }) => {
   // add events
   const methods: Array<string> = [];
-  for (const event of component.events) {
-    if (config.customizedEventHandler?.[event]) {
-      methods.push(config.customizedEventHandler[event]);
+  if ('events' in component) {
+    for (const event of component.events) {
+      if (config.customizedEventHandler?.[event]) {
+        methods.push(config.customizedEventHandler[event]);
+      }
     }
   }
 
   return { methods };
 };
 
-export const wrappedJs = ({ component }: { component: ComponentDesc }) => {
+export const wrappedJs = ({ component }: { component: ComponentDesc | PluginComponentDesc }) => {
   const config = WRAPPED_CONFIGS[component.name] ?? DEFAULT_WRAPPED_CONFIG;
   const { data, properties, attachedInitData } = processWrappedProps({ config, component });
   const { methods } = processWrappedEvents({ config, component });

--- a/packages/webpack-plugin/src/templates/components/wrapped.json.ts
+++ b/packages/webpack-plugin/src/templates/components/wrapped.json.ts
@@ -1,16 +1,22 @@
 import { ComponentDesc } from '../../constants/components';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
 import { nativeComponentJson } from '../commons/nativeComponentJson';
 
 export const wrappedJson = ({
   relativePathToBridge,
   component,
   components,
+  pluginComponents,
 }: {
   relativePathToBridge: string;
-  component: ComponentDesc;
+  component: ComponentDesc | PluginComponentDesc;
   components: ComponentDesc[];
-}) => nativeComponentJson({
+  pluginComponents: PluginComponentDesc[];
+}) =>
+  nativeComponentJson({
+    isComponent: true,
+    isLeaf: component.isLeaf ?? false,
     relativePathToBridge,
     components,
-    isLeaf: component.isLeaf ?? false,
+    pluginComponents,
   });

--- a/packages/webpack-plugin/src/templates/components/wrapped.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/wrapped.wxml.ts
@@ -1,12 +1,13 @@
 import camelCase from 'lodash/camelCase';
 import { ComponentDesc } from '../../constants/components';
+import { PluginComponentDesc } from '../../utils/pluginComponent';
 import { WRAPPED_CONFIGS, DEFAULT_WRAPPED_CONFIG } from '../commons/wrapped';
 import { element, getEventName } from '../commons/wxmlElement';
 import { CommonContext } from '../helpers/context';
 import { getIds } from '../helpers/ids';
 import { t } from '../helpers/t';
 
-export const wrappedWxml = ({ component }: { component: ComponentDesc }) => {
+export const wrappedWxml = ({ component }: { component: ComponentDesc | PluginComponentDesc }) => {
   const ids = getIds();
   const { target } = CommonContext.read();
   const config = WRAPPED_CONFIGS[component.name] ?? DEFAULT_WRAPPED_CONFIG;
@@ -27,12 +28,14 @@ export const wrappedWxml = ({ component }: { component: ComponentDesc }) => {
   }
 
   // add events
-  for (const event of component.events) {
-    const eventName = getEventName({ target, event });
-    if (config.customizedEventHandler?.[event]) {
-      attributes.push(`${eventName}="${camelCase(`on-${event}`)}"`);
-    } else {
-      attributes.push(`${eventName}="e"`);
+  if ('events' in component) {
+    for (const event of component.events) {
+      const eventName = getEventName({ target, event });
+      if (config.customizedEventHandler?.[event]) {
+        attributes.push(`${eventName}="${camelCase(`on-${event}`)}"`);
+      } else {
+        attributes.push(`${eventName}="e"`);
+      }
     }
   }
 

--- a/packages/webpack-plugin/src/utils/__tests__/components.test.ts
+++ b/packages/webpack-plugin/src/utils/__tests__/components.test.ts
@@ -1,17 +1,13 @@
-import { unstable_SimplifyComponent as SimplifyComponent, GojiTarget } from '@goji/core';
-import {
-  getSimplifiedComponents,
-  getWhitelistedComponents,
-  getRenderedComponents,
-} from '../components';
+import { unstable_SimplifyComponent as SimplifyComponent } from '@goji/core';
+import { getSimplifiedComponents, getUsedComponents } from '../components';
 import { getBuiltInComponents } from '../../constants/components';
 
 const COMPONENT_WHITELIST = ['view', 'button', 'text', 'invalid-component'];
 const builtInComponents = getBuiltInComponents('wechat');
 
-describe('getWhitelistedComponents', () => {
-  test('getWhitelistedComponents works', () => {
-    const whitelistedComponents = getWhitelistedComponents('wechat', COMPONENT_WHITELIST);
+describe('getUsedComponents', () => {
+  test('getUsedComponents works', () => {
+    const whitelistedComponents = getUsedComponents('wechat', COMPONENT_WHITELIST);
     expect(whitelistedComponents).toHaveLength(3);
     expect(whitelistedComponents.map(_ => _.name).sort()).toEqual(['button', 'text', 'view']);
   });
@@ -36,35 +32,13 @@ describe('getSimplifiedComponents', () => {
     expect(simplifiedComponents).toHaveLength(2);
 
     expect(simplifiedComponents[0].name).toBe('view');
-    expect(simplifiedComponents[0].sid).toBe(0);
+    expect(simplifiedComponents[0].simplifiedId).toBe(0);
     expect(simplifiedComponents[0].props['hover-class']).not.toBeUndefined();
     expect(simplifiedComponents[0].events).toEqual([]);
 
     expect(simplifiedComponents[1].name).toBe('view');
-    expect(simplifiedComponents[1].sid).toBe(1);
+    expect(simplifiedComponents[1].simplifiedId).toBe(1);
     expect(simplifiedComponents[1].props['hover-class']).not.toBeUndefined();
     expect(simplifiedComponents[1].events).toEqual(['click']);
   });
-});
-
-describe('getRenderedComponents', () => {
-  test.each<[GojiTarget]>([['wechat'], ['baidu'], ['alipay']])(
-    'getRenderedComponents works on %s',
-    target => {
-      const renderedComponents = getRenderedComponents(target, [], COMPONENT_WHITELIST);
-      expect(renderedComponents).toHaveLength(3);
-      for (const renderedComponent of renderedComponents) {
-        for (const event of renderedComponent.events) {
-          if (target === 'wechat' || target === 'baidu') {
-            expect(event.startsWith('bind')).toBe(true);
-            expect(event.includes('-')).toBe(false);
-          } else if (target === 'alipay') {
-            expect(event).toMatch(/^on[A-Z]/i);
-          }
-        }
-      }
-    },
-  );
-
-  test('getRenderedComponents works', () => {});
 });

--- a/packages/webpack-plugin/src/utils/pluginComponent.ts
+++ b/packages/webpack-plugin/src/utils/pluginComponent.ts
@@ -1,12 +1,20 @@
-import { ComponentDesc, ComponentPropDesc } from '../constants/components';
+import { ComponentPropDesc } from '../constants/components';
 
-export const pluginComponents = new Map<string, ComponentDesc>();
+const pluginComponents = new Map<string, PluginComponentDesc>();
+
+export interface PluginComponentDesc {
+  name: string;
+  props: Record<string, ComponentPropDesc>;
+  // TODO: doesn't support `events` for now
+  nativePath: string;
+  isLeaf?: boolean;
+  // TODO: doesn't support `isWrapped` for now
+}
 
 export const registerPluginComponent = (name: string, nativePath: string, props: Array<string>) => {
   if (pluginComponents.has(name)) {
     return;
   }
-  // TODO: doesn't support events for now
   pluginComponents.set(name, {
     name,
     nativePath,
@@ -15,8 +23,8 @@ export const registerPluginComponent = (name: string, nativePath: string, props:
       (propsDesc, prop) => ({ ...propsDesc, [prop]: { required: false, type: 'String' } }),
       {},
     ),
-    events: [],
     isLeaf: true,
-    isWrapped: false,
   });
 };
+
+export const getPluginComponents = () => [...pluginComponents.values()];


### PR DESCRIPTION
This PR refactor internal code without feature changing.It split component desc interface into 3 different types:

* `ComponentDesc`: native components like `view` / `map`.
* `SimplifiedComponentDesc`: `ComponentDesc` with a `simplifiedId`.
* `PluginComponentDesc`: components from plugin which usually has a `nativePath`.