### PR TITLE
Refactor wrapped component with `meta`

### DIFF
--- a/packages/webpack-plugin/src/templates/commons/wrapped.ts
+++ b/packages/webpack-plugin/src/templates/commons/wrapped.ts
@@ -10,9 +10,15 @@ export interface WrappedConfig {
 
 export const DEFAULT_WRAPPED_CONFIG: WrappedConfig = {};
 
-export const updateInternalValueHandler = (event: string) => t`
-  ${camelCase(`on-${event}`)}(evt) {
-    this.data.internalValue = evt.detail.value;
+/**
+ * This function is designed fro convert an uncontrolled component to a controlled component.
+ * E.g. when input on an `<input>` it always re-render and then emit the `bindinput` event, in this
+ * case there is no need to re-render the component again. So we can update `this.data` directly and
+ * `observer` would not update the data anymore.
+ */
+export const updateInternalValueHandler = (eventName: string, propName: string) => t`
+  ${camelCase(`on-${eventName}`)}(evt) {
+    this.data.${camelCase(`internal-${propName}`)}.value = evt.detail.value;
     this.e(evt);
   },`;
 
@@ -20,7 +26,7 @@ export const WRAPPED_CONFIGS: Record<string, WrappedConfig> = {
   input: {
     memorizedProps: ['value', 'focus'],
     customizedEventHandler: {
-      input: updateInternalValueHandler('input'),
+      input: updateInternalValueHandler('input', 'value'),
     },
   },
   map: {
@@ -41,7 +47,7 @@ export const WRAPPED_CONFIGS: Record<string, WrappedConfig> = {
   textarea: {
     memorizedProps: ['value', 'focus'],
     customizedEventHandler: {
-      input: updateInternalValueHandler('input'),
+      input: updateInternalValueHandler('input', 'value'),
     },
   },
   swiper: {
@@ -55,7 +61,7 @@ export const WRAPPED_CONFIGS: Record<string, WrappedConfig> = {
       return t`
         <import src="../components1.wxml" />
         <swiper-item
-          wx:for="{{nodes}}"
+          wx:for="{{${ids.meta}.${ids.children}}}"
           wx:key="${ids.gojiId}"
           class="{{item.${ids.props}.className}}"
           item-id="{{item.${ids.props}.itemId}}"

--- a/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/children.wxml.test.tsx.snap
+++ b/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/children.wxml.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`children.wxml reach max depth 1`] = `"<goji-subtree goji-id=\\"{{meta.gojiId}}\\" nodes=\\"{{meta.children}}\\" />"`;
+exports[`children.wxml reach max depth 1`] = `"<goji-subtree meta=\\"{{meta}}\\" />"`;
 
 exports[`children.wxml works on wechat 1`] = `
 "<import src=\\"./components1.wxml\\" />

--- a/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/wrapped.js.test.tsx.snap
+++ b/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/wrapped.js.test.tsx.snap
@@ -1,103 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`wrapped.js process props: attachedInitData 1`] = `
+Array [
+  "internalScale: {
+  value: this.properties.meta.props.scale
+},",
+]
+`;
+
+exports[`wrapped.js process props: data 1`] = `
+Array [
+  "internalScale: {
+  value: 16
+},",
+]
+`;
+
+exports[`wrapped.js process props: properties 1`] = `
+Array [
+  "meta: {
+  type: Object,
+  observer() {
+    var update = {};
+    if (this.properties.meta.props.scale !== this.data.internalScale.value) {
+      update.internalScale = {
+        value: this.properties.meta.props.scale
+      };
+    }
+    if (Object.keys(update)) {
+      this.setData(update);
+    }
+  },
+},",
+]
+`;
+
 exports[`wrapped.js snapshot works: input 1`] = `
 "Component({
   options: {
     addGlobalClass: true,
   },
   data: {
-    internalValue: \\"\\",
-    internalFocus: false,
+    internalValue: {
+      value: \\"\\"
+    },
+    internalFocus: {
+      value: false
+    },
   },
   properties: {
-    theId: {
-      type: String,
-    },
-    className: {
-      type: String,
-    },
-    theStyle: {
-      type: String,
-    },
-    gojiId: {
-      type: Number,
-    },
-    value: {
-      type: String,
+    meta: {
+      type: Object,
       observer() {
-        if (this.properties.value !== this.data.internalValue) {
-          this.setData({
-            internalValue: this.properties.value,
-          });
+        var update = {};
+        if (this.properties.meta.props.value !== this.data.internalValue.value) {
+          update.internalValue = {
+            value: this.properties.meta.props.value
+          };
+        }
+        if (this.properties.meta.props.focus !== this.data.internalFocus.value) {
+          update.internalFocus = {
+            value: this.properties.meta.props.focus
+          };
+        }
+        if (Object.keys(update)) {
+          this.setData(update);
         }
       },
-    },
-    type: {
-      type: String,
-    },
-    password: {
-      type: Boolean,
-    },
-    placeholder: {
-      type: String,
-    },
-    placeholderStyle: {
-      type: String,
-    },
-    placeholderClass: {
-      type: String,
-    },
-    disabled: {
-      type: Boolean,
-    },
-    maxlength: {
-      type: Number,
-    },
-    cursorSpacing: {
-      type: Number,
-    },
-    autoFocus: {
-      type: Boolean,
-    },
-    focus: {
-      type: Boolean,
-      observer() {
-        if (this.properties.focus !== this.data.internalFocus) {
-          this.setData({
-            internalFocus: this.properties.focus,
-          });
-        }
-      },
-    },
-    confirmType: {
-      type: String,
-    },
-    confirmHold: {
-      type: Boolean,
-    },
-    cursor: {
-      type: Number,
-    },
-    selectionStart: {
-      type: Number,
-    },
-    selectionEnd: {
-      type: Number,
-    },
-    adjustPosition: {
-      type: Boolean,
     },
   },
   lifetimes: {
     attached() {
-      Object.e.subtreeAttached(this.properties.gojiId, this);
+      Object.e.subtreeAttached(this.properties.meta.gojiId, this);
       this.setData({
-        internalValue: this.properties.value,
-        internalFocus: this.properties.focus,
+        internalValue: {
+          value: this.properties.meta.props.value
+        },
+        internalFocus: {
+          value: this.properties.meta.props.focus
+        },
       });
     },
     detached() {
-      Object.e.subtreeDetached(this.properties.gojiId);
+      Object.e.subtreeDetached(this.properties.meta.gojiId);
     },
   },
   methods: {
@@ -105,7 +90,7 @@ exports[`wrapped.js snapshot works: input 1`] = `
       Object.e.trigger(evt);
     },
     onInput(evt) {
-      this.data.internalValue = evt.detail.value;
+      this.data.internalValue.value = evt.detail.value;
       this.e(evt);
     },
   },
@@ -118,131 +103,59 @@ exports[`wrapped.js snapshot works: map 1`] = `
     addGlobalClass: true,
   },
   data: {
-    internalLongitude: 0,
-    internalLatitude: 0,
-    internalScale: 16,
+    internalLongitude: {
+      value: 0
+    },
+    internalLatitude: {
+      value: 0
+    },
+    internalScale: {
+      value: 16
+    },
   },
   properties: {
-    theId: {
-      type: String,
-    },
-    className: {
-      type: String,
-    },
-    theStyle: {
-      type: String,
-    },
-    gojiId: {
-      type: Number,
-    },
-    longitude: {
-      type: Number,
+    meta: {
+      type: Object,
       observer() {
-        if (this.properties.longitude !== this.data.internalLongitude) {
-          this.setData({
-            internalLongitude: this.properties.longitude,
-          });
+        var update = {};
+        if (this.properties.meta.props.longitude !== this.data.internalLongitude.value) {
+          update.internalLongitude = {
+            value: this.properties.meta.props.longitude
+          };
+        }
+        if (this.properties.meta.props.latitude !== this.data.internalLatitude.value) {
+          update.internalLatitude = {
+            value: this.properties.meta.props.latitude
+          };
+        }
+        if (this.properties.meta.props.scale !== this.data.internalScale.value) {
+          update.internalScale = {
+            value: this.properties.meta.props.scale
+          };
+        }
+        if (Object.keys(update)) {
+          this.setData(update);
         }
       },
-    },
-    latitude: {
-      type: Number,
-      observer() {
-        if (this.properties.latitude !== this.data.internalLatitude) {
-          this.setData({
-            internalLatitude: this.properties.latitude,
-          });
-        }
-      },
-    },
-    scale: {
-      type: Number,
-      observer() {
-        if (this.properties.scale !== this.data.internalScale) {
-          this.setData({
-            internalScale: this.properties.scale,
-          });
-        }
-      },
-    },
-    markers: {
-      type: Array,
-    },
-    polyline: {
-      type: Array,
-    },
-    circles: {
-      type: Array,
-    },
-    controls: {
-      type: Array,
-    },
-    includePoints: {
-      type: Array,
-    },
-    showLocation: {
-      type: Boolean,
-    },
-    polygons: {
-      type: Array,
-    },
-    subkey: {
-      type: String,
-    },
-    layerStyle: {
-      type: Number,
-    },
-    rotate: {
-      type: Number,
-    },
-    skew: {
-      type: Number,
-    },
-    enable3D: {
-      type: Boolean,
-    },
-    showCompass: {
-      type: Boolean,
-    },
-    showScale: {
-      type: Boolean,
-    },
-    enableOverlooking: {
-      type: Boolean,
-    },
-    enableZoom: {
-      type: Boolean,
-    },
-    enableScroll: {
-      type: Boolean,
-    },
-    enableRotate: {
-      type: Boolean,
-    },
-    enableSatellite: {
-      type: Boolean,
-    },
-    enableTraffic: {
-      type: Boolean,
-    },
-    enablePoi: {
-      type: Boolean,
-    },
-    enableBuilding: {
-      type: Boolean,
     },
   },
   lifetimes: {
     attached() {
-      Object.e.subtreeAttached(this.properties.gojiId, this);
+      Object.e.subtreeAttached(this.properties.meta.gojiId, this);
       this.setData({
-        internalLongitude: this.properties.longitude,
-        internalLatitude: this.properties.latitude,
-        internalScale: this.properties.scale,
+        internalLongitude: {
+          value: this.properties.meta.props.longitude
+        },
+        internalLatitude: {
+          value: this.properties.meta.props.latitude
+        },
+        internalScale: {
+          value: this.properties.meta.props.scale
+        },
       });
     },
     detached() {
-      Object.e.subtreeDetached(this.properties.gojiId);
+      Object.e.subtreeDetached(this.properties.meta.gojiId);
     },
   },
   methods: {
@@ -263,99 +176,65 @@ exports[`wrapped.js snapshot works: scroll-view 1`] = `
     addGlobalClass: true,
   },
   data: {
-    internalScrollTop: \\"\\",
-    internalScrollLeft: \\"\\",
-    internalScrollIntoView: \\"\\",
+    internalScrollTop: {
+      value: \\"\\"
+    },
+    internalScrollLeft: {
+      value: \\"\\"
+    },
+    internalScrollIntoView: {
+      value: \\"\\"
+    },
   },
   properties: {
-    theId: {
-      type: String,
-    },
-    className: {
-      type: String,
-    },
-    theStyle: {
-      type: String,
-    },
-    gojiId: {
-      type: Number,
-    },
-    nodes: {
+    meta: {
       type: Object,
-    },
-    scrollX: {
-      type: Boolean,
-    },
-    scrollY: {
-      type: Boolean,
-    },
-    upperThreshold: {
-      type: Number,
-    },
-    lowerThreshold: {
-      type: Number,
-    },
-    scrollTop: {
-      type: String,
       observer() {
-        if (this.properties.scrollTop !== this.data.internalScrollTop) {
-          this.setData({
-            internalScrollTop: this.properties.scrollTop,
-          });
+        var update = {};
+        if (this.properties.meta.props.scrollTop !== this.data.internalScrollTop.value) {
+          update.internalScrollTop = {
+            value: this.properties.meta.props.scrollTop
+          };
+        }
+        if (this.properties.meta.props.scrollLeft !== this.data.internalScrollLeft.value) {
+          update.internalScrollLeft = {
+            value: this.properties.meta.props.scrollLeft
+          };
+        }
+        if (this.properties.meta.props.scrollIntoView !== this.data.internalScrollIntoView.value) {
+          update.internalScrollIntoView = {
+            value: this.properties.meta.props.scrollIntoView
+          };
+        }
+        if (Object.keys(update)) {
+          this.setData(update);
         }
       },
-    },
-    scrollLeft: {
-      type: String,
-      observer() {
-        if (this.properties.scrollLeft !== this.data.internalScrollLeft) {
-          this.setData({
-            internalScrollLeft: this.properties.scrollLeft,
-          });
-        }
-      },
-    },
-    scrollIntoView: {
-      type: String,
-      observer() {
-        if (this.properties.scrollIntoView !== this.data.internalScrollIntoView) {
-          this.setData({
-            internalScrollIntoView: this.properties.scrollIntoView,
-          });
-        }
-      },
-    },
-    scrollWithAnimation: {
-      type: Boolean,
-    },
-    enableBackToTop: {
-      type: Boolean,
-    },
-    enableFlex: {
-      type: Boolean,
-    },
-    scrollAnchoring: {
-      type: Boolean,
     },
   },
   lifetimes: {
     attached() {
-      Object.e.subtreeAttached(this.properties.gojiId, this);
+      Object.e.subtreeAttached(this.properties.meta.gojiId, this);
       this.setData({
-        internalScrollTop: this.properties.scrollTop,
-        internalScrollLeft: this.properties.scrollLeft,
-        internalScrollIntoView: this.properties.scrollIntoView,
+        internalScrollTop: {
+          value: this.properties.meta.props.scrollTop
+        },
+        internalScrollLeft: {
+          value: this.properties.meta.props.scrollLeft
+        },
+        internalScrollIntoView: {
+          value: this.properties.meta.props.scrollIntoView
+        },
       });
     },
     detached() {
-      Object.e.subtreeDetached(this.properties.gojiId);
+      Object.e.subtreeDetached(this.properties.meta.gojiId);
     },
   },
   methods: {
     e(evt) {
       Object.e.trigger(evt);
     },
-
   },
 });"
 `;
@@ -366,90 +245,43 @@ exports[`wrapped.js snapshot works: swiper 1`] = `
     addGlobalClass: true,
   },
   data: {
-    internalCurrent: 0,
+    internalCurrent: {
+      value: 0
+    },
   },
   properties: {
-    theId: {
-      type: String,
-    },
-    className: {
-      type: String,
-    },
-    theStyle: {
-      type: String,
-    },
-    gojiId: {
-      type: Number,
-    },
-    nodes: {
+    meta: {
       type: Object,
-    },
-    indicatorDots: {
-      type: Boolean,
-    },
-    indicatorColor: {
-      type: String,
-    },
-    indicatorActiveColor: {
-      type: String,
-    },
-    autoplay: {
-      type: Boolean,
-    },
-    current: {
-      type: Number,
       observer() {
-        if (this.properties.current !== this.data.internalCurrent) {
-          this.setData({
-            internalCurrent: this.properties.current,
-          });
+        var update = {};
+        if (this.properties.meta.props.current !== this.data.internalCurrent.value) {
+          update.internalCurrent = {
+            value: this.properties.meta.props.current
+          };
+        }
+        if (Object.keys(update)) {
+          this.setData(update);
         }
       },
-    },
-    interval: {
-      type: Number,
-    },
-    duration: {
-      type: Number,
-    },
-    circular: {
-      type: Boolean,
-    },
-    vertical: {
-      type: Boolean,
-    },
-    previousMargin: {
-      type: String,
-    },
-    nextMargin: {
-      type: String,
-    },
-    displayMultipleItems: {
-      type: Number,
-    },
-    skipHiddenItemLayout: {
-      type: Boolean,
-    },
-    easingFunction: {
-      type: String,
     },
   },
   lifetimes: {
     attached() {
-      Object.e.subtreeAttached(this.properties.gojiId, this);
+      Object.e.subtreeAttached(this.properties.meta.gojiId, this);
       this.setData({
-        internalCurrent: this.properties.current,
+        internalCurrent: {
+          value: this.properties.meta.props.current
+        },
       });
     },
     detached() {
-      Object.e.subtreeDetached(this.properties.gojiId);
+      Object.e.subtreeDetached(this.properties.meta.gojiId);
     },
   },
   methods: {
     e(evt) {
       Object.e.trigger(evt);
     },
-
   },
 });"
 `;
@@ -460,107 +292,48 @@ exports[`wrapped.js snapshot works: textarea 1`] = `
     addGlobalClass: true,
   },
   data: {
-    internalValue: \\"\\",
-    internalFocus: false,
+    internalValue: {
+      value: \\"\\"
+    },
+    internalFocus: {
+      value: false
+    },
   },
   properties: {
-    theId: {
-      type: String,
-    },
-    className: {
-      type: String,
-    },
-    theStyle: {
-      type: String,
-    },
-    gojiId: {
-      type: Number,
-    },
-    value: {
-      type: String,
+    meta: {
+      type: Object,
       observer() {
-        if (this.properties.value !== this.data.internalValue) {
-          this.setData({
-            internalValue: this.properties.value,
-          });
+        var update = {};
+        if (this.properties.meta.props.value !== this.data.internalValue.value) {
+          update.internalValue = {
+            value: this.properties.meta.props.value
+          };
+        }
+        if (this.properties.meta.props.focus !== this.data.internalFocus.value) {
+          update.internalFocus = {
+            value: this.properties.meta.props.focus
+          };
+        }
+        if (Object.keys(update)) {
+          this.setData(update);
         }
       },
-    },
-    placeholder: {
-      type: String,
-    },
-    placeholderStyle: {
-      type: String,
-    },
-    placeholderClass: {
-      type: String,
-    },
-    disabled: {
-      type: Boolean,
-    },
-    maxlength: {
-      type: Number,
-    },
-    autoFocus: {
-      type: Boolean,
-    },
-    focus: {
-      type: Boolean,
-      observer() {
-        if (this.properties.focus !== this.data.internalFocus) {
-          this.setData({
-            internalFocus: this.properties.focus,
-          });
-        }
-      },
-    },
-    autoHeight: {
-      type: Boolean,
-    },
-    fixed: {
-      type: Boolean,
-    },
-    cursorSpacing: {
-      type: Number,
-    },
-    cursor: {
-      type: Number,
-    },
-    showConfirmBar: {
-      type: Boolean,
-    },
-    selectionStart: {
-      type: Number,
-    },
-    selectionEnd: {
-      type: Number,
-    },
-    adjustPosition: {
-      type: Boolean,
-    },
-    holdKeyboard: {
-      type: Boolean,
-    },
-    disableDefaultPadding: {
-      type: Boolean,
-    },
-    confirmType: {
-      type: String,
-    },
-    confirmHold: {
-      type: Boolean,
     },
   },
   lifetimes: {
     attached() {
-      Object.e.subtreeAttached(this.properties.gojiId, this);
+      Object.e.subtreeAttached(this.properties.meta.gojiId, this);
       this.setData({
-        internalValue: this.properties.value,
-        internalFocus: this.properties.focus,
+        internalValue: {
+          value: this.properties.meta.props.value
+        },
+        internalFocus: {
+          value: this.properties.meta.props.focus
+        },
       });
     },
     detached() {
-      Object.e.subtreeDetached(this.properties.gojiId);
+      Object.e.subtreeDetached(this.properties.meta.gojiId);
     },
   },
   methods: {
@@ -568,7 +341,7 @@ exports[`wrapped.js snapshot works: textarea 1`] = `
       Object.e.trigger(evt);
     },
     onInput(evt) {
-      this.data.internalValue = evt.detail.value;
+      this.data.internalValue.value = evt.detail.value;
       this.e(evt);
     },
   },
@@ -581,107 +354,48 @@ exports[`wrapped.js snapshot works: textarea 2`] = `
     addGlobalClass: true,
   },
   data: {
-    internalValue: \\"\\",
-    internalFocus: false,
+    internalValue: {
+      value: \\"\\"
+    },
+    internalFocus: {
+      value: false
+    },
   },
   properties: {
-    theId: {
-      type: String,
-    },
-    className: {
-      type: String,
-    },
-    theStyle: {
-      type: String,
-    },
-    gojiId: {
-      type: Number,
-    },
-    value: {
-      type: String,
+    meta: {
+      type: Object,
       observer() {
-        if (this.properties.value !== this.data.internalValue) {
-          this.setData({
-            internalValue: this.properties.value,
-          });
+        var update = {};
+        if (this.properties.meta.props.value !== this.data.internalValue.value) {
+          update.internalValue = {
+            value: this.properties.meta.props.value
+          };
+        }
+        if (this.properties.meta.props.focus !== this.data.internalFocus.value) {
+          update.internalFocus = {
+            value: this.properties.meta.props.focus
+          };
+        }
+        if (Object.keys(update)) {
+          this.setData(update);
         }
       },
-    },
-    placeholder: {
-      type: String,
-    },
-    placeholderStyle: {
-      type: String,
-    },
-    placeholderClass: {
-      type: String,
-    },
-    disabled: {
-      type: Boolean,
-    },
-    maxlength: {
-      type: Number,
-    },
-    autoFocus: {
-      type: Boolean,
-    },
-    focus: {
-      type: Boolean,
-      observer() {
-        if (this.properties.focus !== this.data.internalFocus) {
-          this.setData({
-            internalFocus: this.properties.focus,
-          });
-        }
-      },
-    },
-    autoHeight: {
-      type: Boolean,
-    },
-    fixed: {
-      type: Boolean,
-    },
-    cursorSpacing: {
-      type: Number,
-    },
-    cursor: {
-      type: Number,
-    },
-    showConfirmBar: {
-      type: Boolean,
-    },
-    selectionStart: {
-      type: Number,
-    },
-    selectionEnd: {
-      type: Number,
-    },
-    adjustPosition: {
-      type: Boolean,
-    },
-    holdKeyboard: {
-      type: Boolean,
-    },
-    disableDefaultPadding: {
-      type: Boolean,
-    },
-    confirmType: {
-      type: String,
-    },
-    confirmHold: {
-      type: Boolean,
     },
   },
   lifetimes: {
     attached() {
-      Object.e.subtreeAttached(this.properties.gojiId, this);
+      Object.e.subtreeAttached(this.properties.meta.gojiId, this);
       this.setData({
-        internalValue: this.properties.value,
-        internalFocus: this.properties.focus,
+        internalValue: {
+          value: this.properties.meta.props.value
+        },
+        internalFocus: {
+          value: this.properties.meta.props.focus
+        },
       });
     },
     detached() {
-      Object.e.subtreeDetached(this.properties.gojiId);
+      Object.e.subtreeDetached(this.properties.meta.gojiId);
     },
   },
   methods: {
@@ -689,7 +403,7 @@ exports[`wrapped.js snapshot works: textarea 2`] = `
       Object.e.trigger(evt);
     },
     onInput(evt) {
-      this.data.internalValue = evt.detail.value;
+      this.data.internalValue.value = evt.detail.value;
       this.e(evt);
     },
   },

--- a/packages/webpack-plugin/src/templates/components/__tests__/components.wxml.test.tsx
+++ b/packages/webpack-plugin/src/templates/components/__tests__/components.wxml.test.tsx
@@ -66,15 +66,7 @@ describe('componentAttributes', () => {
       renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
         componentAttributes({ component }),
       ),
-    ).toEqual(
-      expect.arrayContaining([
-        'nodes="{{meta.children}}"',
-        'goji-id="{{meta.gojiId || -1}}"',
-        'class-name="{{meta.props.className}}"',
-        'the-id="{{meta.props.id}}"',
-        `the-style="{{meta.props.style || ''}}"`,
-      ]),
-    );
+    ).toEqual(expect.arrayContaining(['meta="{{meta}}"']));
   });
 
   test('events', () => {

--- a/packages/webpack-plugin/src/templates/components/children.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/children.wxml.ts
@@ -22,6 +22,6 @@ export const childrenWxml = ({
     `;
   }
   return t`
-    <goji-subtree goji-id="{{${ids.meta}.${ids.gojiId}}}" nodes="{{${ids.meta}.${ids.children}}}" />
+    <goji-subtree ${ids.meta}="{{${ids.meta}}}" />
   `;
 };

--- a/packages/webpack-plugin/src/templates/components/subtree.js.ts
+++ b/packages/webpack-plugin/src/templates/components/subtree.js.ts
@@ -1,15 +1,16 @@
+import { getIds } from '../helpers/ids';
 import { t } from '../helpers/t';
 
-export const subtreeJs = () => t`
+export const subtreeJs = () => {
+  const ids = getIds();
+
+  return t`
     Component({
       options: {
         addGlobalClass: true,
       },
       properties: {
-        gojiId: {
-          type: Number,
-        },
-        nodes: {
+        ${ids.meta}: {
           type: Object,
         },
       },
@@ -20,11 +21,12 @@ export const subtreeJs = () => t`
       },
       lifetimes: {
         attached() {
-          Object.e.subtreeAttached(this.properties.gojiId, this);
+          Object.e.subtreeAttached(this.properties.${ids.meta}.${ids.gojiId}, this);
         },
         detached() {
-          Object.e.subtreeDetached(this.properties.gojiId);
+          Object.e.subtreeDetached(this.properties.${ids.meta}.${ids.gojiId});
         },
       },
     });
   `;
+};

--- a/packages/webpack-plugin/src/templates/components/subtree.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/subtree.wxml.ts
@@ -7,7 +7,7 @@ export const subtreeWxml = () => {
   return t`
     <import src="./components0.wxml" />
 
-    <block wx:for="{{nodes}}" wx:key="${ids.gojiId}">
+    <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
       <template is="$$GOJI_COMPONENT0" data="{{ ${ids.meta}: item }}" />
     </block>
   `;

--- a/packages/webpack-plugin/src/templates/components/wrapped.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/wrapped.wxml.ts
@@ -6,26 +6,26 @@ import { element, getEventName } from '../commons/wxmlElement';
 import { CommonContext } from '../helpers/context';
 import { getIds } from '../helpers/ids';
 import { t } from '../helpers/t';
+import { mapComponentPropsToAttributes, componentAttribute } from './components.wxml';
 
 export const wrappedWxml = ({ component }: { component: ComponentDesc | PluginComponentDesc }) => {
   const ids = getIds();
   const { target } = CommonContext.read();
   const config = WRAPPED_CONFIGS[component.name] ?? DEFAULT_WRAPPED_CONFIG;
-  const attributes: Array<string> = [];
-  attributes.push(
-    'id="{{theId}}"',
-    'class="{{className}}"',
-    'style="{{theStyle}}"',
-    'data-goji-id="{{gojiId}}"',
-  );
-  // add props
-  for (const [propName] of Object.entries(component.props)) {
-    if (config.memorizedProps?.includes(propName)) {
-      attributes.push(`${propName}="{{${camelCase(`internal-${propName}`)}}}"`);
-    } else {
-      attributes.push(`${propName}="{{${camelCase(propName)}}}"`);
-    }
-  }
+  const attributes: Array<string> = [
+    `data-goji-id="{{${ids.meta}.${ids.gojiId} || -1}}"`,
+    // common attributes
+    componentAttribute({ name: 'class', value: 'className' }),
+    componentAttribute({ name: 'id', value: 'id' }),
+    componentAttribute({ name: 'style', value: 'style', fallback: '' }),
+    ...mapComponentPropsToAttributes(component).map(_ =>
+      config.memorizedProps?.includes(_.name)
+        ? // element attributes with memorized
+          `${_.name}="{{${camelCase(`internal-${_.name}`)}.value}}"`
+        : // element attributes without memorized
+          componentAttribute(_),
+    ),
+  ];
 
   // add events
   if ('events' in component) {
@@ -48,7 +48,7 @@ export const wrappedWxml = ({ component }: { component: ComponentDesc | PluginCo
     }
     return t`
       <import src="../components0.wxml" />
-      <block wx:for="{{nodes}}" wx:key="${ids.gojiId}">
+      <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
         <template is="$$GOJI_COMPONENT0" data="{{ ${ids.meta}: item }}" />
       </block>
     `;


### PR DESCRIPTION
There is no need to separate passing every props into a wrapped component and a `meta` variable is enough. Therefor we can refactor current implement to save more bundle size.

<img width="1864" alt="image" src="https://user-images.githubusercontent.com/1812118/204002043-bb44961d-92bb-44c3-80d1-79d492c2c47f.png">
