### PR TITLE
Refactor template reuse & fix `getSubtreeId`

### DIFF
--- a/packages/core/src/components/subtree.ts
+++ b/packages/core/src/components/subtree.ts
@@ -3,7 +3,7 @@ import { TYPE_SUBTREE } from '../constants';
 
 export const useSubtree = process.env.GOJI_TARGET === 'wechat' || process.env.GOJI_TARGET === 'qq';
 
-export const getSubtreeMaxDepthFromConfig = (process.env.GOJI_MAX_DEPTH as any as number) ?? 10;
+export const subtreeMaxDepthFromConfig = (process.env.GOJI_MAX_DEPTH as any as number) ?? 10;
 
 export const Subtree = ({
   unsafe_className: className,

--- a/packages/core/src/components/subtree.ts
+++ b/packages/core/src/components/subtree.ts
@@ -1,18 +1,17 @@
 import React, { createElement, Fragment, CSSProperties } from 'react';
-import { TYPE_SUBTREE, GOJI_TARGET } from '../constants';
+import { TYPE_SUBTREE } from '../constants';
 
-export const useSubtree = GOJI_TARGET === 'wechat' || GOJI_TARGET === 'qq';
+export const useSubtree = process.env.GOJI_TARGET === 'wechat' || process.env.GOJI_TARGET === 'qq';
 
-export const subtreeMaxDepth = (process.env.GOJI_MAX_DEPTH as any as number) ?? 10;
+export const getSubtreeMaxDepthFromConfig = (process.env.GOJI_MAX_DEPTH as any as number) ?? 10;
 
 export const Subtree = ({
   unsafe_className: className,
   unsafe_style: style,
   ...restProps
-}: // eslint-disable-next-line camelcase
-React.PropsWithChildren<{ unsafe_className?: string; unsafe_style?: CSSProperties }>) => {
+}: React.PropsWithChildren<{ unsafe_className?: string; unsafe_style?: CSSProperties }>) => {
   if (useSubtree) {
-    return createElement(useSubtree ? TYPE_SUBTREE : Fragment, {
+    return createElement(TYPE_SUBTREE, {
       className,
       style,
       ...restProps,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -4,8 +4,6 @@ export const TYPE_SUBTREE = 'GOJI_TYPE_SUBTREE';
 
 export type GojiTarget = 'wechat' | 'baidu' | 'alipay' | 'toutiao' | 'qq' | 'toutiao';
 
-export const GOJI_TARGET: GojiTarget = (process.env.GOJI_TARGET as GojiTarget) || 'wechat';
-
 export interface SimplifyComponent {
   name: string;
   properties: Array<string>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import './patchGlobalObject';
 import { createAdaptor, AdaptorType, ExportComponentMeta } from './adaptor';
-import { GOJI_TARGET } from './constants';
+import { GojiTarget } from './constants';
 import { batchedUpdates } from './reconciler';
 
 interface RenderOptions {
@@ -21,7 +21,12 @@ export const render = (element: ReactNode, options: Partial<RenderOptions> = {})
     ...DEFAULT_RENDER_OPTIONS,
     ...options,
   };
-  const adaptor = createAdaptor(type, GOJI_TARGET, exportMeta, disablePageSharing);
+  const adaptor = createAdaptor(
+    type,
+    process.env.GOJI_TARGET as GojiTarget,
+    exportMeta,
+    disablePageSharing,
+  );
   return adaptor.run(element);
 };
 

--- a/packages/core/src/reconciler/__tests__/getSubtreeId.noSubtree.test.tsx
+++ b/packages/core/src/reconciler/__tests__/getSubtreeId.noSubtree.test.tsx
@@ -1,0 +1,50 @@
+import { ElementInstance } from '../instance';
+import { Container } from '../../container';
+import { GOJI_VIRTUAL_ROOT, TYPE_SUBTREE } from '../../constants';
+import { TestingAdaptorInstance } from '../../__tests__/helpers/adaptor';
+
+jest.mock('../../components/subtree', () => ({
+  useSubtree: false,
+  subtreeMaxDepthFromConfig: 5,
+}));
+
+beforeAll(() => {
+  // @ts-expect-error
+  process.env.GOJI_WRAPPED_COMPONENTS = [];
+});
+const view = () => new ElementInstance('view', {}, [], new Container(new TestingAdaptorInstance()));
+const subtree = () =>
+  new ElementInstance(TYPE_SUBTREE, {}, [], new Container(new TestingAdaptorInstance()));
+/**
+ * linkElements
+ * call `setParent` and `children.push` for given elements
+ * [a, b, c] => a <- b <- c
+ */
+const linkElements = (elements: Array<ElementInstance>) => {
+  const mockContainer = new Container(new TestingAdaptorInstance());
+  const mockRoot = new ElementInstance(GOJI_VIRTUAL_ROOT, {}, [], mockContainer);
+  elements[0].setParent(mockRoot);
+  for (let i = 0; i < elements.length - 1; i += 1) {
+    elements[i].appendChild(elements[i + 1]);
+  }
+};
+
+describe('no subtree', () => {
+  test('subtree id should be always undefined', () => {
+    let leaf: ElementInstance;
+    const elements = [
+      view(),
+      view(),
+      subtree(),
+      view(),
+      view(),
+      view(),
+      view(),
+      view(),
+      view(),
+      (leaf = view()),
+    ];
+    linkElements(elements);
+    expect(leaf.getSubtreeId()).toBe(undefined);
+  });
+});

--- a/packages/core/src/reconciler/__tests__/getSubtreeId.test.tsx
+++ b/packages/core/src/reconciler/__tests__/getSubtreeId.test.tsx
@@ -1,0 +1,74 @@
+import { ElementInstance } from '../instance';
+import { Container } from '../../container';
+import { GOJI_VIRTUAL_ROOT, TYPE_SUBTREE } from '../../constants';
+import { TestingAdaptorInstance } from '../../__tests__/helpers/adaptor';
+
+jest.mock('../../components/subtree', () => ({
+  useSubtree: true,
+  subtreeMaxDepthFromConfig: 5,
+}));
+
+beforeAll(() => {
+  // @ts-expect-error
+  process.env.GOJI_WRAPPED_COMPONENTS = [];
+});
+const view = () => new ElementInstance('view', {}, [], new Container(new TestingAdaptorInstance()));
+const subtree = () =>
+  new ElementInstance(TYPE_SUBTREE, {}, [], new Container(new TestingAdaptorInstance()));
+/**
+ * linkElements
+ * call `setParent` and `children.push` for given elements
+ * [a, b, c] => a <- b <- c
+ */
+const linkElements = (elements: Array<ElementInstance>) => {
+  const mockContainer = new Container(new TestingAdaptorInstance());
+  const mockRoot = new ElementInstance(GOJI_VIRTUAL_ROOT, {}, [], mockContainer);
+  elements[0].setParent(mockRoot);
+  for (let i = 0; i < elements.length - 1; i += 1) {
+    elements[i].appendChild(elements[i + 1]);
+  }
+};
+
+describe('use subtree', () => {
+  test('container works', () => {
+    let leaf: ElementInstance;
+    const elements = [view(), view(), (leaf = view())];
+    linkElements(elements);
+    expect(leaf.getSubtreeId()).toBe(undefined);
+  });
+
+  test('auto subtree works', () => {
+    let leaf: ElementInstance;
+    let sub: ElementInstance;
+    const elements = [view(), view(), view(), view(), (sub = view()), view(), (leaf = view())];
+    linkElements(elements);
+    expect(leaf.getSubtreeId()).toBe(sub.id);
+  });
+
+  test('manual subtree works', () => {
+    let leaf: ElementInstance;
+    let sub: ElementInstance;
+    const elements = [view(), view(), (sub = subtree()), view(), (leaf = view())];
+    linkElements(elements);
+    expect(leaf.getSubtreeId()).toBe(sub.id);
+  });
+
+  test('auto subtree inside manual subtree works', () => {
+    let leaf: ElementInstance;
+    let sub: ElementInstance;
+    const elements = [
+      view(),
+      view(),
+      subtree(),
+      view(),
+      view(),
+      view(),
+      view(),
+      (sub = view()),
+      view(),
+      (leaf = view()),
+    ];
+    linkElements(elements);
+    expect(leaf.getSubtreeId()).toBe(sub.id);
+  });
+});

--- a/packages/core/src/reconciler/__tests__/instance.test.tsx
+++ b/packages/core/src/reconciler/__tests__/instance.test.tsx
@@ -1,18 +1,13 @@
 import React, { useState, createRef } from 'react';
 import { ElementInstance, ElementNodeDevelopment, TextNodeDevelopment } from '../instance';
 import { Container } from '../../container';
-import { TYPE_SUBTREE } from '../../constants';
+import { GOJI_VIRTUAL_ROOT, TYPE_SUBTREE } from '../../constants';
 import { View, gojiEvents } from '../..';
 import { act } from '../../testUtils';
 import { batchedUpdates } from '..';
 import { PublicInstance } from '../publicInstance';
 import { render } from '../../__tests__/helpers';
 import { TestingAdaptorInstance } from '../../__tests__/helpers/adaptor';
-
-jest.mock('../../../src/components/subtree', () => ({
-  useSubtree: true,
-  subtreeMaxDepth: 5,
-}));
 
 describe('ElementInstance', () => {
   const instance = new ElementInstance(
@@ -66,7 +61,8 @@ describe('ElementInstance', () => {
      */
     const linkElements = (elements: Array<ElementInstance>) => {
       const mockContainer = new Container(new TestingAdaptorInstance());
-      elements[0].setParent(mockContainer);
+      const mockRoot = new ElementInstance(GOJI_VIRTUAL_ROOT, {}, [], mockContainer);
+      elements[0].setParent(mockRoot);
       for (let i = 0; i < elements.length - 1; i += 1) {
         elements[i].appendChild(elements[i + 1]);
       }
@@ -75,6 +71,7 @@ describe('ElementInstance', () => {
     describe('wechat', () => {
       beforeAll(() => {
         process.env.GOJI_TARGET = 'wechat';
+        process.env.GOJI_MAX_DEPTH = 5 as any;
       });
 
       test('container works', () => {
@@ -123,9 +120,10 @@ describe('ElementInstance', () => {
     describe('non-wechat', () => {
       beforeAll(() => {
         process.env.GOJI_TARGET = 'baidu';
+        process.env.GOJI_MAX_DEPTH = 5 as any;
       });
 
-      test('subtree id should be always undefined', () => {
+      test.only('subtree id should be always undefined', () => {
         let leaf: ElementInstance;
         const elements = [
           view(),

--- a/packages/core/src/reconciler/__tests__/instance.test.tsx
+++ b/packages/core/src/reconciler/__tests__/instance.test.tsx
@@ -1,7 +1,6 @@
 import React, { useState, createRef } from 'react';
 import { ElementInstance, ElementNodeDevelopment, TextNodeDevelopment } from '../instance';
 import { Container } from '../../container';
-import { GOJI_VIRTUAL_ROOT, TYPE_SUBTREE } from '../../constants';
 import { View, gojiEvents } from '../..';
 import { act } from '../../testUtils';
 import { batchedUpdates } from '..';
@@ -10,6 +9,11 @@ import { render } from '../../__tests__/helpers';
 import { TestingAdaptorInstance } from '../../__tests__/helpers/adaptor';
 
 describe('ElementInstance', () => {
+  beforeAll(() => {
+    // @ts-expect-error
+    process.env.GOJI_WRAPPED_COMPONENTS = [];
+  });
+
   const instance = new ElementInstance(
     'view',
     {
@@ -43,104 +47,6 @@ describe('ElementInstance', () => {
     );
     const [pured] = simpleInstance.pure('');
     expect((pured as ElementNodeDevelopment).simplifiedId).not.toBeUndefined();
-  });
-
-  describe('getSubtreeId', () => {
-    beforeAll(() => {
-      // @ts-expect-error
-      process.env.GOJI_WRAPPED_COMPONENTS = [];
-    });
-    const view = () =>
-      new ElementInstance('view', {}, [], new Container(new TestingAdaptorInstance()));
-    const subtree = () =>
-      new ElementInstance(TYPE_SUBTREE, {}, [], new Container(new TestingAdaptorInstance()));
-    /**
-     * linkElements
-     * call `setParent` and `children.push` for given elements
-     * [a, b, c] => a <- b <- c
-     */
-    const linkElements = (elements: Array<ElementInstance>) => {
-      const mockContainer = new Container(new TestingAdaptorInstance());
-      const mockRoot = new ElementInstance(GOJI_VIRTUAL_ROOT, {}, [], mockContainer);
-      elements[0].setParent(mockRoot);
-      for (let i = 0; i < elements.length - 1; i += 1) {
-        elements[i].appendChild(elements[i + 1]);
-      }
-    };
-
-    describe('wechat', () => {
-      beforeAll(() => {
-        process.env.GOJI_TARGET = 'wechat';
-        process.env.GOJI_MAX_DEPTH = 5 as any;
-      });
-
-      test('container works', () => {
-        let leaf: ElementInstance;
-        const elements = [view(), view(), (leaf = view())];
-        linkElements(elements);
-        expect(leaf.getSubtreeId()).toBe(undefined);
-      });
-
-      test('auto subtree works', () => {
-        let leaf: ElementInstance;
-        let sub: ElementInstance;
-        const elements = [view(), view(), view(), view(), (sub = view()), view(), (leaf = view())];
-        linkElements(elements);
-        expect(leaf.getSubtreeId()).toBe(sub.id);
-      });
-
-      test('manual subtree works', () => {
-        let leaf: ElementInstance;
-        let sub: ElementInstance;
-        const elements = [view(), view(), (sub = subtree()), view(), (leaf = view())];
-        linkElements(elements);
-        expect(leaf.getSubtreeId()).toBe(sub.id);
-      });
-
-      test('auto subtree inside manual subtree works', () => {
-        let leaf: ElementInstance;
-        let sub: ElementInstance;
-        const elements = [
-          view(),
-          view(),
-          subtree(),
-          view(),
-          view(),
-          view(),
-          view(),
-          (sub = view()),
-          view(),
-          (leaf = view()),
-        ];
-        linkElements(elements);
-        expect(leaf.getSubtreeId()).toBe(sub.id);
-      });
-    });
-
-    describe('non-wechat', () => {
-      beforeAll(() => {
-        process.env.GOJI_TARGET = 'baidu';
-        process.env.GOJI_MAX_DEPTH = 5 as any;
-      });
-
-      test.only('subtree id should be always undefined', () => {
-        let leaf: ElementInstance;
-        const elements = [
-          view(),
-          view(),
-          subtree(),
-          view(),
-          view(),
-          view(),
-          view(),
-          view(),
-          view(),
-          (leaf = view()),
-        ];
-        linkElements(elements);
-        expect(leaf.getSubtreeId()).toBe(undefined);
-      });
-    });
   });
 
   test('batched event handler', () => {

--- a/packages/core/src/reconciler/instance.ts
+++ b/packages/core/src/reconciler/instance.ts
@@ -5,7 +5,7 @@ import { getNextInstanceId } from '../utils/id';
 import { styleAttrStringify } from '../utils/styleAttrStringify';
 import { findSimplifyId } from '../utils/simplify';
 import { shallowEqual } from '../utils/shallowEqual';
-import { getSubtreeMaxDepthFromConfig, useSubtree } from '../components/subtree';
+import { subtreeMaxDepthFromConfig, useSubtree } from '../components/subtree';
 import { batchedUpdates } from '.';
 
 // prop types from ComponentDesc
@@ -103,8 +103,7 @@ export class ElementInstance extends BaseInstance {
   public subtreeDepth?: number;
 
   public getSubtreeId(): number | undefined {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const subtreeMaxDepth = useSubtree ? getSubtreeMaxDepthFromConfig : Infinity;
+    const subtreeMaxDepth = useSubtree ? subtreeMaxDepthFromConfig : Infinity;
     // wrapped component should return its wrapper as subtree id
     // `process.env.GOJI_WRAPPED_COMPONENTS` is generated from `@goji/webpack-plugin` to tell which
     // components are wrapped as custom components
@@ -126,7 +125,6 @@ export class ElementInstance extends BaseInstance {
       }
       // wrapped component creates a new subtree
       if (
-        // eslint-disable-next-line react-hooks/rules-of-hooks
         (useSubtree && cursor.type === TYPE_SUBTREE) ||
         wrappedComponentsFromWebpack.includes(cursor.type)
       ) {

--- a/packages/webpack-plugin/src/constants/features.ts
+++ b/packages/webpack-plugin/src/constants/features.ts
@@ -3,10 +3,14 @@ import { GojiTarget } from '@goji/core';
 export const getFeatures = (target: GojiTarget) => ({
   useSubtree: target === 'wechat' || target === 'qq',
 
-  // alipay only support recursion dependency self to self so we have to inline the children.wxml
+  // Alipay only support recursion dependency self to self so we have to inline the children.wxml
   // Success: A -> A -> A
   // Fail: A -> B -> A
-  useInlineChildren: target === 'alipay',
+  useInlineChildrenInComponent: target === 'alipay',
+
+  // Baidu fails to render if an outside same `<include>` exists
+  // https://github.com/airbnb/goji-js/issues/185
+  useInlineChildrenInItem: target === 'baidu',
 
   // Baidu doesn't support `template` inside `text` so we need to flat text manually
   useFlattenText: target === 'baidu',

--- a/packages/webpack-plugin/src/templates/commons/wrapped.ts
+++ b/packages/webpack-plugin/src/templates/commons/wrapped.ts
@@ -59,17 +59,15 @@ export const WRAPPED_CONFIGS: Record<string, WrappedConfig> = {
       const ids = getIds();
 
       return t`
-        <import src="../components1.wxml" />
         <swiper-item
           wx:for="{{${ids.meta}.${ids.children}}}"
           wx:key="${ids.gojiId}"
-          class="{{item.${ids.props}.className}}"
-          item-id="{{item.${ids.props}.itemId}}"
-          data-goji-id="{{item.${ids.gojiId}}}"
+          wx:for-item="${ids.meta}"
+          class="{{${ids.meta}.${ids.props}.className}}"
+          item-id="{{${ids.meta}.${ids.props}.itemId}}"
+          data-goji-id="{{${ids.meta}.${ids.gojiId}}}"
         >
-          <block wx:for="{{item.${ids.children}}}" wx:key="${ids.gojiId}">
-            <template is="$$GOJI_COMPONENT1" data="{{ ${ids.meta}: item }}" />
-          </block>
+          <include src="../children1.wxml" />
         </swiper-item>
       `;
     },

--- a/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/children.wxml.test.tsx.snap
+++ b/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/children.wxml.test.tsx.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`children.wxml reach max depth 1`] = `"<goji-subtree meta=\\"{{meta}}\\" />"`;
-
-exports[`children.wxml works on wechat 1`] = `
+exports[`children.wxml works 1`] = `
 "<import src=\\"./components1.wxml\\" />
 <block wx:for=\\"{{meta.children}}\\" wx:key=\\"gojiId\\">
   <template is=\\"$$GOJI_COMPONENT1\\" data=\\"{{ meta: item }}\\" />

--- a/packages/webpack-plugin/src/templates/components/__tests__/children.wxml.test.tsx
+++ b/packages/webpack-plugin/src/templates/components/__tests__/children.wxml.test.tsx
@@ -2,34 +2,12 @@ import { renderTemplate } from '../..';
 import { childrenWxml } from '../children.wxml';
 
 describe('children.wxml', () => {
-  test('works on wechat', () => {
+  test('works', () => {
     expect(
       renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
         childrenWxml({
-          componentsDepth: 1,
-          maxDepth: 5,
-        }),
-      ),
-    ).toMatchSnapshot();
-  });
-
-  test('fix Baidu undefined not work bug', () => {
-    expect(
-      renderTemplate({ target: 'baidu', nodeEnv: 'development' }, () =>
-        childrenWxml({
-          componentsDepth: 1,
-          maxDepth: 5,
-        }),
-      ),
-    ).toContain('data="{{ meta: item }}"');
-  });
-
-  test('reach max depth', () => {
-    expect(
-      renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
-        childrenWxml({
-          componentsDepth: 5,
-          maxDepth: 5,
+          relativePathToBridge: '.',
+          componentDepth: 1,
         }),
       ),
     ).toMatchSnapshot();

--- a/packages/webpack-plugin/src/templates/components/__tests__/wrapped.js.test.tsx
+++ b/packages/webpack-plugin/src/templates/components/__tests__/wrapped.js.test.tsx
@@ -37,10 +37,12 @@ describe('wrapped.js', () => {
   };
 
   test('process props', () => {
-    const result = processWrappedProps({
-      component: mockMapComponent,
-      config: mockConfig,
-    });
+    const result = renderTemplate({ target: 'wechat', nodeEnv: 'development' }, () =>
+      processWrappedProps({
+        component: mockMapComponent,
+        config: mockConfig,
+      }),
+    );
     expect(result.data).toMatchSnapshot('data');
     expect(result.properties).toMatchSnapshot('properties');
     expect(result.attachedInitData).toMatchSnapshot('attachedInitData');

--- a/packages/webpack-plugin/src/templates/components/children.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/children.wxml.ts
@@ -1,27 +1,27 @@
 import { getIds } from '../helpers/ids';
 import { t } from '../helpers/t';
 
+export const noNeedImport = Symbol('no need to import component template');
+
 export const childrenWxml = ({
-  componentsDepth,
-  maxDepth,
+  relativePathToBridge,
+  componentDepth,
 }: {
-  componentsDepth: number;
-  maxDepth: number;
+  relativePathToBridge: string | typeof noNeedImport;
+  componentDepth: number;
 }) => {
   const ids = getIds();
 
-  if (componentsDepth < maxDepth) {
-    return t`
-      <import src="./components${componentsDepth}.wxml" />
-      <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
-        ${
-          // pass the whole object to prevent this bug https://github.com/airbnb/goji-js/issues/179
-          t`<template is="$$GOJI_COMPONENT${componentsDepth}" data="{{ ${ids.meta}: item }}" />`
-        }
-      </block>
-    `;
-  }
   return t`
-    <goji-subtree ${ids.meta}="{{${ids.meta}}}" />
+    ${
+      relativePathToBridge !== noNeedImport &&
+      `<import src="${relativePathToBridge}/components${componentDepth}.wxml" />`
+    }
+    <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
+      ${
+        // pass the whole object to prevent this bug https://github.com/airbnb/goji-js/issues/179
+        t`<template is="$$GOJI_COMPONENT${componentDepth}" data="{{ ${ids.meta}: item }}" />`
+      }
+    </block>
   `;
 };

--- a/packages/webpack-plugin/src/templates/components/item.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/item.wxml.ts
@@ -1,16 +1,19 @@
-import { getIds } from '../helpers/ids';
+import { getFeatures } from '../../constants/features';
+import { CommonContext } from '../helpers/context';
 import { t } from '../helpers/t';
+import { childrenWxml } from './children.wxml';
 
 export const itemWxml = ({ relativePathToBridge }: { relativePathToBridge: string }) => {
-  const ids = getIds();
-  // pass the whole object to prevent this bug https://github.com/airbnb/goji-js/issues/179
-  const children = t`<template is="$$GOJI_COMPONENT0" data="{{ ${ids.meta}: item }}" />`;
+  const { useInlineChildrenInItem } = getFeatures(CommonContext.read().target);
+
+  if (useInlineChildrenInItem) {
+    return childrenWxml({
+      relativePathToBridge,
+      componentDepth: 0,
+    });
+  }
 
   return t`
-    <import src="${relativePathToBridge}/components0.wxml"/>
-
-    <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
-      ${children}
-    </block>
+    <include src="${relativePathToBridge}/children0.wxml" />
   `;
 };

--- a/packages/webpack-plugin/src/templates/components/leaf-components.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/leaf-components.wxml.ts
@@ -21,10 +21,9 @@ export const leafComponentWxml = ({
         .map(component =>
           componentItem({
             component,
-            // FIXME: remove this filed
-            depth: -1,
-            // FIXME: remove this filed
-            componentsDepth: -1,
+            // useless fields
+            componentDepth: NaN,
+            childrenDepth: NaN,
           }),
         )
     }

--- a/packages/webpack-plugin/src/templates/components/subtree.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/subtree.wxml.ts
@@ -1,14 +1,19 @@
-import { getIds } from '../helpers/ids';
+import { getFeatures } from '../../constants/features';
+import { CommonContext } from '../helpers/context';
 import { t } from '../helpers/t';
+import { childrenWxml } from './children.wxml';
 
 export const subtreeWxml = () => {
-  const ids = getIds();
+  const { useInlineChildrenInItem } = getFeatures(CommonContext.read().target);
+
+  if (useInlineChildrenInItem) {
+    return childrenWxml({
+      relativePathToBridge: '.',
+      componentDepth: 0,
+    });
+  }
 
   return t`
-    <import src="./components0.wxml" />
-
-    <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
-      <template is="$$GOJI_COMPONENT0" data="{{ ${ids.meta}: item }}" />
-    </block>
+    <include src="./children0.wxml" />
   `;
 };

--- a/packages/webpack-plugin/src/templates/components/wrapped.js.ts
+++ b/packages/webpack-plugin/src/templates/components/wrapped.js.ts
@@ -1,4 +1,3 @@
-import { getTemplateIds } from '@goji/core/dist/cjs/constants';
 import camelCase from 'lodash/camelCase';
 import { ComponentDesc, ComponentPropDesc } from '../../constants/components';
 import { PluginComponentDesc } from '../../utils/pluginComponent';
@@ -27,7 +26,7 @@ export const processWrappedProps = ({
   component: ComponentDesc | PluginComponentDesc;
   config: WrappedConfig;
 }) => {
-  const ids = getTemplateIds();
+  const ids = getIds();
   const data: Array<string> = [];
   const metaObserverChecks: Array<string> = [];
   const attachedInitData: Array<string> = [];

--- a/packages/webpack-plugin/src/templates/components/wrapped.wxml.ts
+++ b/packages/webpack-plugin/src/templates/components/wrapped.wxml.ts
@@ -1,11 +1,13 @@
 import camelCase from 'lodash/camelCase';
 import { ComponentDesc } from '../../constants/components';
+import { getFeatures } from '../../constants/features';
 import { PluginComponentDesc } from '../../utils/pluginComponent';
 import { WRAPPED_CONFIGS, DEFAULT_WRAPPED_CONFIG } from '../commons/wrapped';
 import { element, getEventName } from '../commons/wxmlElement';
 import { CommonContext } from '../helpers/context';
 import { getIds } from '../helpers/ids';
 import { t } from '../helpers/t';
+import { childrenWxml } from './children.wxml';
 import { mapComponentPropsToAttributes, componentAttribute } from './components.wxml';
 
 export const wrappedWxml = ({ component }: { component: ComponentDesc | PluginComponentDesc }) => {
@@ -46,11 +48,15 @@ export const wrappedWxml = ({ component }: { component: ComponentDesc | PluginCo
     if (component.isLeaf) {
       return '';
     }
+    const { useInlineChildrenInItem } = getFeatures(CommonContext.read().target);
+    if (useInlineChildrenInItem) {
+      return childrenWxml({
+        relativePathToBridge: '..',
+        componentDepth: 0,
+      });
+    }
     return t`
-      <import src="../components0.wxml" />
-      <block wx:for="{{${ids.meta}.${ids.children}}}" wx:key="${ids.gojiId}">
-        <template is="$$GOJI_COMPONENT0" data="{{ ${ids.meta}: item }}" />
-      </block>
+      <include src="../children0.wxml" />
     `;
   })();
 


### PR DESCRIPTION
1. Refactored `item.wxml` to reuse existing `children0.wxml`.

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/1812118/204097261-1f9b04ed-3591-4ac5-b9cc-b00be984fd88.png">

2. Fixed an bug in `getSubtreeId` that cause this function always return `undefined`. The root cause is https://github.com/airbnb/goji-js/pull/77 replace root container with new `GOJI_VIRTUAL_ROOT` element but I forgot to update the `getSubtreeId` logics.