### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Change Log
 
+# v1.1.0 (2022-12-06)
+
+### Features
+
+- **webpack-plugin:** Enable wrapped input/textarea for baidu
+  [\#165](https://github.com/airbnb/goji-js/pull/165)
+
+- **webpack-plugin:** Refactored the data structure in template and `setData` JSON data.
+  [\#180](https://github.com/airbnb/goji-js/pull/180)
+
+- **webpack-plugin:** Refactor ComponentDesc [\#181](https://github.com/airbnb/goji-js/pull/181)
+
+- **webpack-plugin:** Refactor wrapped component with `meta`
+  [\#182](https://github.com/airbnb/goji-js/pull/182)
+
+- **core:** Support NodeJS 18 [\#184](https://github.com/airbnb/goji-js/pull/184)
+
+- **webpack-plugin:** Refactor template reuse & fix `getSubtreeId`
+  [\#186](https://github.com/airbnb/goji-js/pull/186)
+
+### Bugfixes
+
+- **create-goji-app:** Remove default `libVersion` fields in `project.config.json`
+  [\#164](https://github.com/airbnb/goji-js/pull/164)
+
+- **cli:** Upgrade deps & fix missing linaria issue in create CLI template
+  [\#175](https://github.com/airbnb/goji-js/pull/175)
+
+### Misc.
+
+- **docs:** Upgrade docs to docusaurus v2 [\#166](https://github.com/airbnb/goji-js/pull/166)
+
+- **docs:** Add missing CNAME file for docs [\#170](https://github.com/airbnb/goji-js/pull/170)
+
 # v1.0.1 (2022-04-13)
 
 ### Features

--- a/packages/beemo-dev/configs/lerna.ts
+++ b/packages/beemo-dev/configs/lerna.ts
@@ -4,7 +4,7 @@ const config: LernaConfig = {
   packages: ['packages/*', 'packages/goji.js.org/*'],
   npmClient: 'yarn',
   useWorkspaces: true,
-  version: '1.0.1',
+  version: '1.1.0',
 };
 
 export default config;

--- a/packages/beemo-dev/package.json
+++ b/packages/beemo-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/beemo-dev",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Beemo Config for GojiJS Development",
   "main": "src/index.ts",
   "repository": "https://github.com/airbnb/goji-js.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/cli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS CLI",
   "main": "dist/cjs/index.js",
   "bin": {
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-react": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
-    "@goji/webpack-plugin": "^1.0.1",
+    "@goji/webpack-plugin": "^1.1.0",
     "babel-loader": "^8.2.1",
     "babel-plugin-macros": "^3.1.0",
     "css-loader": "^6.5.1",
@@ -49,7 +49,7 @@
     "yargs": "^17.1.0"
   },
   "devDependencies": {
-    "@goji/core": "^1.0.1",
+    "@goji/core": "^1.1.0",
     "@types/yargs": "^17.0.2"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS Core",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/create-goji-app/package.json
+++ b/packages/create-goji-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-goji-app",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Create GojiJS App",
   "main": "index.js",
   "repository": "https://github.com/airbnb/goji-js",

--- a/packages/demo-todomvc-linaria/package.json
+++ b/packages/demo-todomvc-linaria/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-todomvc-linaria",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS Linaria Example",
   "main": "index.js",
   "repository": "git+https://github.com/airbnb/goji.git",
@@ -13,7 +13,7 @@
     "build": "goji build"
   },
   "dependencies": {
-    "@goji/core": "^1.0.1",
+    "@goji/core": "^1.1.0",
     "classnames": "^2.2.6",
     "core-js": "^3.16.0",
     "linaria": "^2.3.0",
@@ -23,8 +23,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@goji/cli": "^1.0.1",
-    "@goji/testing-library": "^1.0.1",
+    "@goji/cli": "^1.1.0",
+    "@goji/testing-library": "^1.1.0",
     "@types/classnames": "^2.2.10",
     "@types/css-modules": "^1.0.0",
     "@types/react": "^17.0.31",

--- a/packages/demo-todomvc/package.json
+++ b/packages/demo-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-todomvc",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS TodoMVC Example",
   "main": "index.js",
   "repository": "git+https://github.com/airbnb/goji.git",
@@ -13,8 +13,8 @@
     "build": "goji build"
   },
   "dependencies": {
-    "@goji/core": "^1.0.1",
-    "@goji/macro": "^1.0.1",
+    "@goji/core": "^1.1.0",
+    "@goji/macro": "^1.1.0",
     "classnames": "^2.2.6",
     "core-js": "^3.16.0",
     "linaria": "^2.3.0",
@@ -24,9 +24,9 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@goji/beemo-dev": "^1.0.1",
-    "@goji/cli": "^1.0.1",
-    "@goji/testing-library": "^1.0.1",
+    "@goji/beemo-dev": "^1.1.0",
+    "@goji/cli": "^1.1.0",
+    "@goji/testing-library": "^1.1.0",
     "@types/classnames": "^2.2.10",
     "@types/css-modules": "^1.0.0",
     "@types/react": "^17.0.31",

--- a/packages/goji.js.org/package.json
+++ b/packages/goji.js.org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goji-js-org",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "crowdin": "crowdin",

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/macro",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS binding for babel-plugin-macros",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -25,8 +25,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@goji/core": "^1.0.1",
-    "@goji/webpack-plugin": "^1.0.1",
+    "@goji/core": "^1.1.0",
+    "@goji/webpack-plugin": "^1.1.0",
     "@types/babel-plugin-macros": "^2.8.5",
     "react": "^17.0.2"
   },

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/testing-library",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS Testing Library",
   "main": "dist/cjs/index.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "react": "*"
   },
   "devDependencies": {
-    "@goji/core": "^1.0.1",
+    "@goji/core": "^1.1.0",
     "@types/lodash": "^4.14.172",
     "@types/react-test-renderer": "^17.0.1",
     "react": "^17.0.2"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goji/webpack-plugin",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GojiJS Webpack Plugin",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@goji/core": "^1.0.1",
+    "@goji/core": "^1.1.0",
     "@types/common-tags": "^1.8.1",
     "@types/enhanced-resolve": "^3.0.7",
     "@types/find-cache-dir": "^3.2.1",


### PR DESCRIPTION
# v1.1.0 (2022-12-06)

### Features

- **webpack-plugin:** Enable wrapped input/textarea for baidu
  [\#165](https://github.com/airbnb/goji-js/pull/165)

- **webpack-plugin:** Refactored the data structure in template and `setData` JSON data.
  [\#180](https://github.com/airbnb/goji-js/pull/180)

- **webpack-plugin:** Refactor ComponentDesc [\#181](https://github.com/airbnb/goji-js/pull/181)

- **webpack-plugin:** Refactor wrapped component with `meta`
  [\#182](https://github.com/airbnb/goji-js/pull/182)

- **core:** Support NodeJS 18 [\#184](https://github.com/airbnb/goji-js/pull/184)

- **webpack-plugin:** Refactor template reuse & fix `getSubtreeId`
  [\#186](https://github.com/airbnb/goji-js/pull/186)

### Bugfixes

- **create-goji-app:** Remove default `libVersion` fields in `project.config.json`
  [\#164](https://github.com/airbnb/goji-js/pull/164)

- **cli:** Upgrade deps & fix missing linaria issue in create CLI template
  [\#175](https://github.com/airbnb/goji-js/pull/175)

### Misc.

- **docs:** Upgrade docs to docusaurus v2 [\#166](https://github.com/airbnb/goji-js/pull/166)
