### PR TITLE
Inline the content of `children.wxml` into `component.wxml` to support new Baidu compiler on dev tool >= v4.22

### DIFF
--- a/packages/webpack-plugin/src/constants/features.ts
+++ b/packages/webpack-plugin/src/constants/features.ts
@@ -3,10 +3,15 @@ import { GojiTarget } from '@goji/core';
 export const getFeatures = (target: GojiTarget) => ({
   useSubtree: target === 'wechat' || target === 'qq',
 
-  // Alipay only support recursion dependency self to self so we have to inline the children.wxml
-  // Success: A -> A -> A
-  // Fail: A -> B -> A
-  useInlineChildrenInComponent: target === 'alipay',
+  useInlineChildrenInComponent:
+    // Alipay only support circular dependency self to self so we have to inline the children.wxml
+    // Success: A -> A -> A
+    // Fail: A -> B -> A
+    target === 'alipay' ||
+    // Baidu changes the behavior of circular dependency on dev tool >= v4.22 with new compiler
+    // so we have to inline the children.wxml
+    // https://smartprogram.baidu.com/docs/develop/devtools/beta-notify#_5-%E6%A8%A1%E6%9D%BF-import-%E8%AF%AD%E6%B3%95%E4%B8%8D%E5%85%81%E8%AE%B8%E5%BE%AA%E7%8E%AF%E5%BC%95%E7%94%A8%E3%80%82
+    target === 'baidu',
 
   // Baidu fails to render if an outside same `<include>` exists
   // https://github.com/airbnb/goji-js/issues/185


### PR DESCRIPTION
Before, circular dependency like `include` -> `import` -> `include` works on Baidu. After Baidu upgrade its new compiler on dev tool >= v4.22, it throws an error at compiling time.

<img width="701" alt="image" src="https://github.com/airbnb/goji-js/assets/1812118/1800c0a2-b3be-4f49-9792-c84f2839a2aa">

To fix the issue, we can reuse the `useInlineChildrenInComponent` feature which Alipay already enabled. This feature copies the content of `children.wxml` into `component.wxml` and could increase a little bundle size.

Docs: https://smartprogram.baidu.com/docs/develop/devtools/beta-notify#_5-%E6%A8%A1%E6%9D%BF-import-%E8%AF%AD%E6%B3%95%E4%B8%8D%E5%85%81%E8%AE%B8%E5%BE%AA%E7%8E%AF%E5%BC%95%E7%94%A8%E3%80%82
