### PR TITLE
support fire load and error event in test library

### DIFF
--- a/packages/testing-library/src/__tests__/events.test.tsx
+++ b/packages/testing-library/src/__tests__/events.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, View, Text, Input } from '@goji/core';
+import { Button, View, Text, Input, Image } from '@goji/core';
 import { render, fireEvent } from '..';
 
 describe('fireEvent', () => {
@@ -42,5 +42,30 @@ describe('fireEvent', () => {
     expect(wrapper.getByTestId('input').props.value).toBe('hello');
     fireEvent.input(wrapper.getByTestId('input'), 'world');
     expect(wrapper.getByTestId('input').props.value).toBe('world');
+  });
+
+  test('load and error', () => {
+    let state = 'hello';
+
+    const App = ({ callback }: { callback: (s: string) => void }) => (
+      <Image
+        testID="image"
+        src="test.jpg"
+        onLoad={() => callback('ok')}
+        onError={() => callback('error')}
+      />
+    );
+    const wrapper = render(
+      <App
+        callback={v => {
+          state = v;
+        }}
+      />,
+    );
+    expect(state).toBe('hello');
+    fireEvent.load(wrapper.getByTestId('image'));
+    expect(state).toBe('ok');
+    fireEvent.error(wrapper.getByTestId('image'));
+    expect(state).toBe('error');
   });
 });

--- a/packages/testing-library/src/events.ts
+++ b/packages/testing-library/src/events.ts
@@ -1,7 +1,12 @@
 import { ReactTestInstance, act } from 'react-test-renderer';
 import { validComponentFilter } from './utils/queryHelpers';
 
-const buildTargetInfo = (node: ReactTestInstance) => ({ offsetLeft: 0, offsetTop: 0, id: node.props.id, dataset: {} });
+const buildTargetInfo = (node: ReactTestInstance) => ({
+  offsetLeft: 0,
+  offsetTop: 0,
+  id: node.props.id,
+  dataset: {},
+});
 
 const fireEventOnInstance = ({
   node,
@@ -68,6 +73,26 @@ class FireEvent {
       node,
       type: 'confirm',
       eventName: 'onConfirm',
+      detail: { value: node.props.value },
+      bubble: false,
+    });
+  }
+
+  public static load(node: ReactTestInstance) {
+    fireEventOnInstance({
+      node,
+      type: 'load',
+      eventName: 'onLoad',
+      detail: { value: node.props.value },
+      bubble: false,
+    });
+  }
+
+  public static error(node: ReactTestInstance) {
+    fireEventOnInstance({
+      node,
+      type: 'error',
+      eventName: 'onError',
       detail: { value: node.props.value },
       bubble: false,
     });


### PR DESCRIPTION
In some case, we need to test `onLoad` and `onError` event on Image component, in this PR we extends the FireEvent lib to support those events.