### PR TITLE
Disable code protect option for wechat and qq

### DIFF
--- a/packages/create-goji-app/templates/src/project.config.json
+++ b/packages/create-goji-app/templates/src/project.config.json
@@ -11,7 +11,7 @@
     "newFeature": true,
     "nodeModules": false,
     "autoAudits": false,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",

--- a/packages/create-goji-app/templates/src/project.qq.json
+++ b/packages/create-goji-app/templates/src/project.qq.json
@@ -9,7 +9,7 @@
     "autoAudits": false,
     "nodeModules": false,
     "uploadWithSourceMap": true,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "remoteDebugLogEnable": false,
     "prefetch": false
   },

--- a/packages/demo-todomvc-linaria/src/project.config.json
+++ b/packages/demo-todomvc-linaria/src/project.config.json
@@ -11,7 +11,7 @@
     "newFeature": true,
     "nodeModules": false,
     "autoAudits": false,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",

--- a/packages/demo-todomvc-linaria/src/project.qq.json
+++ b/packages/demo-todomvc-linaria/src/project.qq.json
@@ -9,7 +9,7 @@
     "autoAudits": false,
     "nodeModules": false,
     "uploadWithSourceMap": true,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "remoteDebugLogEnable": false,
     "prefetch": false
   },

--- a/packages/demo-todomvc/src/project.config.json
+++ b/packages/demo-todomvc/src/project.config.json
@@ -11,7 +11,7 @@
     "newFeature": true,
     "nodeModules": false,
     "autoAudits": false,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",

--- a/packages/demo-todomvc/src/project.qq.json
+++ b/packages/demo-todomvc/src/project.qq.json
@@ -9,7 +9,7 @@
     "autoAudits": false,
     "nodeModules": false,
     "uploadWithSourceMap": true,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "remoteDebugLogEnable": false,
     "prefetch": false
   },

--- a/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.config.json
+++ b/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.config.json
@@ -11,7 +11,7 @@
     "newFeature": true,
     "nodeModules": false,
     "autoAudits": false,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "checkInvalidKey": true
   },
   "compileType": "miniprogram",

--- a/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.qq.json
+++ b/packages/webpack-plugin/src/plugins/__tests__/fixtures/hoist/src/project.qq.json
@@ -9,7 +9,7 @@
     "autoAudits": false,
     "nodeModules": false,
     "uploadWithSourceMap": true,
-    "uglifyFileName": true,
+    "uglifyFileName": false,
     "remoteDebugLogEnable": false,
     "prefetch": false
   },


### PR DESCRIPTION
[Code protects](https://developers.weixin.qq.com/miniprogram/dev/devtools/project.html#%E6%9C%AC%E5%9C%B0%E8%AE%BE%E7%BD%AE) fails to work on some 3rd-party library like [lodash](https://github.com/lodash/lodash/blob/2da024c3b4f9947a48517639de7560457cd4ec6c/.internal/nodeTypes.js#L20). This PR disabled that option for `create-goji-app` and demo apps.

<img width="356" alt="image" src="https://github.com/airbnb/goji-js/assets/1812118/a22c8eb7-bca6-4b60-ba8d-5f90212892d0">
