### PR TITLE
Enable `nohoist` by default

### DIFF
--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -19,7 +19,6 @@ export class GojiWebpackPlugin implements webpack.WebpackPluginInstance {
     options: GojiWebpackPluginOptions,
   ): GojiWebpackPluginRequiredOptions {
     const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV ?? 'development';
-    const isProd = nodeEnv === 'production';
 
     return {
       target: options.target,
@@ -27,7 +26,7 @@ export class GojiWebpackPlugin implements webpack.WebpackPluginInstance {
       maxDepth: options.maxDepth ?? 5,
       minimize: options.minimize ?? nodeEnv !== 'development',
       nohoist: {
-        enable: options?.nohoist?.enable ?? isProd,
+        enable: options?.nohoist?.enable ?? true,
         maxPackages: options?.nohoist?.maxPackages ?? 1,
         test: options?.nohoist?.test,
       },


### PR DESCRIPTION
In https://github.com/airbnb/goji-js/pull/120 it said _`nohoist.enable` is set to false in development mode to speed up code bundling._ 
But recently we meet an unexpected issue, that some global CSS styles in a page polluted other page. Consider we have a sub-package `packageA` and a page `packageA/pages/index` inside it with these CSS:

```css
:global() {
  page {
    background-color: red;
  }
}
```

If `nohoist.enable` was `false`, these lines of code would be bundled into `_goji_commons.wxss` and shared by all pages. Which means all pages' background became red.

Therefore, I decided to enable this option by default in case of different behavior on production and development mode.

Also, I tested and found the bundling performance affect is acceptable. See the result of re-bundling time costs ( in ms ) in a large GojiJS project.

| `nohoist.enable`                                               | `false`  | `true`   | Delta |
| -------------------------------------------------------------- | -------- | -------- | ----- |
| Re-bundling test 1                                             | 2312     | 2358     |       |
| Re-bundling test 2                                             | 1952     | 1840     |       |
| Re-bundling test 3                                             | 2014     | 2032     |       |
| Re-bundling test 4                                             | 1779     | 2116     |       |
| Re-bundling test 5                                             | 1928     | 1886     |       |
| Re-bundling test 6                                             | 1882     | 1927     |       |
| Re-bundling test 7                                             | 2012     | 1794     |       |
| Re-bundling test 8                                             | 1902     | 1848     |       |
| Re-bundling test 9                                             | 1894     | 1907     |       |
| Re-bundling test 10                                            | 1939     | 2029     |       |
| Average                                                        | 1961.4   | 1973.7   | 0.63% |
| [Truncated mean](https://en.wikipedia.org/wiki/Truncated_mean) | 1940.375 | 1948.125 | 0.40% |