### PR TITLE
Add `parallel` option in goji.config.js

### DIFF
--- a/packages/cli/src/config/loaders.ts
+++ b/packages/cli/src/config/loaders.ts
@@ -7,23 +7,23 @@ export const getEnvForPreprocess = (nodeEnv: string, target: GojiTarget) => ({
   TARGET: target,
 });
 
-// `thread-loader` enable multi-thread compiling for Webpack
 const MOST_ECONOMICAL_WORKER_COUNT = 3;
-
-// FIXME: cannot use `thread-loader`'s `warmup` because of this issue
-// https://github.com/webpack-contrib/thread-loader/issues/122
-export const getThreadLoader = (nodeEnv: string): Array<webpack.RuleSetRule> => {
-  // disable `thread-loader` on CI
-  if (process.env.CI === 'true') {
-    return [];
-  }
+const getDefaultWorkerCount = () => {
   // `thead-loader`'s workers default to `os.cpus().length - 1`
   // after benchmarking I believe 1 master + 3 workers = 4 thread should be the most economical config on most cpus
   // so we use `max(1, min(core_count - 1, MOST_ECONOMICAL_WORKER_COUNT))` as worker count
   const threadCount = os.cpus()?.length ?? 1;
-  const workerCount = Math.max(1, Math.min(threadCount - 1, MOST_ECONOMICAL_WORKER_COUNT));
+  return Math.max(1, Math.min(threadCount - 1, MOST_ECONOMICAL_WORKER_COUNT));
+};
+
+// FIXME: cannot use `thread-loader`'s `warmup` because of this issue
+// https://github.com/webpack-contrib/thread-loader/issues/122
+export const getThreadLoader = (nodeEnv: string, parallel?: number): Array<webpack.RuleSetRule> => {
+  if (typeof parallel === 'number' && parallel <= 1) {
+    return [];
+  }
   const options = {
-    workers: workerCount,
+    workers: typeof parallel === 'number' ? parallel - 1 : getDefaultWorkerCount(),
     // no need to kill the worker in dev mode for better re-build performance
     poolTimeout: nodeEnv === 'production' ? 2000 : Infinity,
   };

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -43,6 +43,7 @@ export const getWebpackConfig = ({
   watch,
   progress,
   nohoist,
+  parallel,
 }: {
   basedir: string;
   outputPath?: string;
@@ -52,8 +53,12 @@ export const getWebpackConfig = ({
   watch: boolean;
   progress: boolean;
   nohoist?: GojiWebpackPluginOptions['nohoist'];
+  parallel?: {
+    minimize?: number;
+    loader?: number;
+  };
 }): webpack.Configuration => {
-  const threadLoaders = getThreadLoader(nodeEnv);
+  const threadLoaders = getThreadLoader(nodeEnv, parallel?.loader);
 
   const CSS_FILE_EXT = {
     wechat: 'wxss',
@@ -99,6 +104,7 @@ export const getWebpackConfig = ({
             },
           },
           extractComments: false,
+          parallel: parallel?.minimize,
         }),
       ],
       // set `optimization.splitChunks` and `optimization.splitChunks` to `false`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,12 @@ interface GojiConfig {
   configureBabel?: (config: any) => any;
   progress?: boolean;
   nohoist?: GojiWebpackPluginOptions['nohoist'];
+  parallel?:
+    | {
+        minimize?: number;
+        loader?: number;
+      }
+    | number;
 }
 
 const GOJI_CONFIG_FILE_NAME = 'goji.config';
@@ -60,6 +66,10 @@ const main = async () => {
     watch,
     progress: gojiConfig.progress ?? cliConfig.progress ?? true,
     nohoist: gojiConfig?.nohoist,
+    parallel:
+      typeof gojiConfig.parallel === 'number'
+        ? { loader: gojiConfig.parallel, minimize: gojiConfig.parallel }
+        : gojiConfig.parallel,
   });
 
   // apply goji.config.js configureWebpack


### PR DESCRIPTION
This PR adds a new option `parallel` in `goji.config.js`.

```tsx
interface GojiConfig {
  ...
  parallel?:
    | {
        minimize?: number;
        loader?: number;
      }
    | number;
}
```

The `parallel.minimize` corresponds the `parallel` option within [`TerserWebpackPlugin`](https://webpack.js.org/plugins/terser-webpack-plugin/), while the `parallel.loader` corresponds the `workers` option within [`thread-loader`](https://webpack.js.org/loaders/thread-loader/).