### PR TITLE
Fix Webpack cache invalidation

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,17 +22,17 @@ interface GojiConfig {
 }
 
 const GOJI_CONFIG_FILE_NAME = 'goji.config';
-const requireGojiConfig = (basedir: string): GojiConfig => {
+const requireGojiConfig = (basedir: string): [string | undefined, GojiConfig] => {
   let resolvedPath: string;
   try {
     resolvedPath = resolve.sync(path.join(basedir, GOJI_CONFIG_FILE_NAME));
   } catch (error) {
     console.info(`\`goji.config.js\` not found in folder ${basedir}, using default config.`);
-    return {};
+    return [undefined, {}];
   }
 
   // eslint-disable-next-line global-require, import/no-dynamic-require
-  return require(resolvedPath);
+  return [resolvedPath, require(resolvedPath)];
 };
 
 const main = async () => {
@@ -49,7 +49,7 @@ const main = async () => {
   process.env.NODE_ENV = cliConfig.production ? 'production' : 'development';
   process.env.GOJI_TARGET = cliConfig.target;
 
-  const gojiConfig = requireGojiConfig(basedir);
+  const [gojiConfigFile, gojiConfig] = requireGojiConfig(basedir);
   // eslint-disable-next-line global-require
   const babelConfig = require('./config/babel.config');
   if (gojiConfig.configureBabel) {
@@ -59,6 +59,7 @@ const main = async () => {
   const watch = cliConfig.watch ?? gojiConfig.watch ?? !cliConfig.production;
   const webpackConfig = getWebpackConfig({
     basedir,
+    gojiConfigFile,
     outputPath: gojiConfig.outputPath,
     target: cliConfig.target,
     nodeEnv: cliConfig.production ? 'production' : 'development',


### PR DESCRIPTION
The Webpack cache should be invalidated if:

1. The build target has changed, i.e., when using `yarn start [target]`.
2. The GojiJS version has changed, typically after updating the GojiJS CLI.
3. There has been a change in the `webpack.config.js`. This recommendation is provided in the [Webpack cache configuration documentation](https://webpack.js.org/configuration/cache/#cachebuilddependencies). Additionally, this has been implemented in [Webpack CLI](https://github.com/webpack/webpack-cli/blob/ef09fee7185e5c80efd3de1c98260e61f1e63ba0/packages/webpack-cli/src/webpack-cli.ts#L2279-L2300).
4. There is a change in the `goji.config.js`. This is crucial because users often modify `goji.config.js` to adjust the build configuration.
