### PR TITLE
Refactor CSS unit transforming

### DIFF
--- a/packages/cli/src/config/postcssConfig.ts
+++ b/packages/cli/src/config/postcssConfig.ts
@@ -1,29 +1,58 @@
 /* eslint-disable global-require */
 
+export type TransformUnit = 'keep' | 'to-px' | 'to-rpx';
+
+const getTransformUnitsPlugin = (unit: TransformUnit) => {
+  switch (unit) {
+    case 'keep':
+      return [];
+    case 'to-px':
+      // use this plugin because some plugins, like postcss-calc, don't support `rpx` unit
+      return [
+        require('./postcssTransformUnit')({
+          divisor: 2,
+          multiple: 1,
+          sourceUnit: 'rpx',
+          targetUnit: 'px',
+        }),
+      ];
+    case 'to-rpx':
+      return [
+        require('./postcssTransformUnit')({
+          divisor: 1,
+          multiple: 2,
+          sourceUnit: 'px',
+          targetUnit: 'rpx',
+        }),
+      ];
+    default:
+      throw new Error(`Unknown unit ${unit}`);
+  }
+};
+
 // to improve PostCSS performance, we should always use `require(name)(options)` rather than `[name, options]`
 // also we should set `postcssOptions.config` to `false` to avoid loading any `postcss.config.js`
 // TODO: hope PostCSS could fix this issue https://github.com/csstools/postcss-preset-env/issues/232#issuecomment-992263741
-export default {
-  plugins: [
-    require('postcss-each')(),
-    // TODO: `postcss-nesting` from `postcss-preset-env` output `:is` pseudo-class that
-    // Mini Programs don't support.
-    // We have to `postcss-nested` manually before them to prevent `:is` being created.
-    require('postcss-nested'),
-    require('postcss-preset-env')({
-      stage: 0,
-      preserve: false, // for reducing file size
-      insertAfter: {
-        // postcss-calc must run before autoprefixer
-        'environment-variables': require('postcss-calc')(),
-      },
-    }),
-    // use postcss-px2units because some plugins, like postcss-calc, don't support `rpx` unit
-    require('./postcssPx2units')({
-      multiple: 2,
-      targetUnits: 'rpx',
-    }),
-    require('cssnano')({ preset: 'default' }),
-    require('postcss-reporter')({ clearReportedMessages: true }),
-  ],
+export default ({ unit }: { unit: TransformUnit }) => {
+  const transformUnitPlugin = getTransformUnitsPlugin(unit);
+
+  return {
+    plugins: [
+      require('postcss-each')(),
+      // TODO: `postcss-nesting` from `postcss-preset-env` output `:is` pseudo-class that Mini Programs don't support.
+      // We have to use `postcss-nested` manually before them to prevent `:is` being created.
+      require('postcss-nested')(),
+      require('postcss-preset-env')({
+        stage: 0,
+        preserve: false,
+        insertAfter: {
+          // postcss-calc must run before autoprefixer
+          'environment-variables': require('postcss-calc')(),
+        },
+      }),
+      ...transformUnitPlugin,
+      require('cssnano')({ preset: 'default' }),
+      require('postcss-reporter')({ clearReportedMessages: true }),
+    ],
+  };
 };

--- a/packages/cli/src/config/postcssTransformUnit.ts
+++ b/packages/cli/src/config/postcssTransformUnit.ts
@@ -7,7 +7,8 @@ interface Options {
   divisor: number;
   multiple: number;
   decimalPlaces: number;
-  targetUnits: string;
+  sourceUnit: string;
+  targetUnit: string;
   comment: string;
 }
 
@@ -15,11 +16,12 @@ const DEFAULT_OPTIONS: Options = {
   divisor: 1,
   multiple: 1,
   decimalPlaces: 2,
-  targetUnits: 'rpx',
+  sourceUnit: 'px',
+  targetUnit: 'rpx',
   comment: 'no',
 };
 
-const postcssPx2units: PluginCreator<Partial<Options>> = (options = {}) => {
+const postcssTransformUnit: PluginCreator<Partial<Options>> = (options = {}) => {
   const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
 
   const replacePx = (str: string) => {
@@ -27,16 +29,19 @@ const postcssPx2units: PluginCreator<Partial<Options>> = (options = {}) => {
       return '';
     }
 
-    return str.replace(/\b(\d+(\.\d+)?)px\b/gi, (match, x) => {
-      const size = (x * mergedOptions.multiple) / mergedOptions.divisor;
-      return size % 1 === 0
-        ? size + mergedOptions.targetUnits
-        : size.toFixed(mergedOptions.decimalPlaces) + mergedOptions.targetUnits;
-    });
+    return str.replace(
+      new RegExp(`\\b(\\d+(\\.\\d+)?)${mergedOptions.sourceUnit}\\b`, 'g'),
+      (_match, x) => {
+        const size = (x * mergedOptions.multiple) / mergedOptions.divisor;
+        return size % 1 === 0
+          ? size + mergedOptions.targetUnit
+          : size.toFixed(mergedOptions.decimalPlaces) + mergedOptions.targetUnit;
+      },
+    );
   };
 
   return {
-    postcssPlugin: 'postcss-px2units',
+    postcssPlugin: 'postcss-transform-unit',
     Declaration(declaration) {
       const nextNode = declaration.next();
       if (nextNode?.type === 'comment' && nextNode.text === mergedOptions.comment) {
@@ -48,6 +53,6 @@ const postcssPx2units: PluginCreator<Partial<Options>> = (options = {}) => {
   };
 };
 
-postcssPx2units.postcss = true;
+postcssTransformUnit.postcss = true;
 
-module.exports = postcssPx2units;
+module.exports = postcssTransformUnit;

--- a/packages/cli/src/config/webpack.config.ts
+++ b/packages/cli/src/config/webpack.config.ts
@@ -11,7 +11,7 @@ import resolve from 'resolve';
 import { version as gojiCliVersion } from '@goji/cli/package.json';
 import { version as babelCoreVersion } from '@babel/core/package.json';
 import { version as babelLoaderVersion } from 'babel-loader/package.json';
-import postcssConfig from './postcssConfig';
+import postcssConfig, { TransformUnit } from './postcssConfig';
 import { getThreadLoader } from './loaders';
 
 const getSourceMap = (nodeEnv: string, target: GojiTarget): webpack.Configuration['devtool'] => {
@@ -46,6 +46,7 @@ export const getWebpackConfig = ({
   watch,
   progress,
   nohoist,
+  cssUnit,
   parallel,
 }: {
   basedir: string;
@@ -57,6 +58,7 @@ export const getWebpackConfig = ({
   watch: boolean;
   progress: boolean;
   nohoist?: GojiWebpackPluginOptions['nohoist'];
+  cssUnit: TransformUnit;
   parallel?: {
     minimize?: number;
     loader?: number;
@@ -230,7 +232,7 @@ export const getWebpackConfig = ({
                 implementation: require.resolve('postcss'),
                 postcssOptions: {
                   config: false,
-                  ...postcssConfig,
+                  ...postcssConfig({ unit: cssUnit }),
                 },
               },
             },
@@ -267,7 +269,7 @@ export const getWebpackConfig = ({
                 implementation: require.resolve('postcss'),
                 postcssOptions: {
                   config: false,
-                  ...postcssConfig,
+                  ...postcssConfig({ unit: cssUnit }),
                 },
               },
             },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { GojiWebpackPluginOptions } from '@goji/webpack-plugin';
 import { getWebpackConfig } from './config/webpack.config';
 import { parseArgv, CliConfig } from './argv';
 import './utils/fixSerializationWarning';
+import { TransformUnit } from './config/postcssConfig';
 
 interface GojiConfig {
   watch?: boolean;
@@ -13,6 +14,9 @@ interface GojiConfig {
   configureBabel?: (config: any) => any;
   progress?: boolean;
   nohoist?: GojiWebpackPluginOptions['nohoist'];
+  css?: {
+    unit?: TransformUnit;
+  };
   parallel?:
     | {
         minimize?: number;
@@ -67,6 +71,7 @@ const main = async () => {
     watch,
     progress: gojiConfig.progress ?? cliConfig.progress ?? true,
     nohoist: gojiConfig?.nohoist,
+    cssUnit: gojiConfig?.css?.unit ?? 'to-rpx',
     parallel:
       typeof gojiConfig.parallel === 'number'
         ? { loader: gojiConfig.parallel, minimize: gojiConfig.parallel }

--- a/packages/demo-todomvc-linaria/goji.config.js
+++ b/packages/demo-todomvc-linaria/goji.config.js
@@ -1,1 +1,5 @@
-module.exports = {};
+module.exports = {
+  css: {
+    unit: 'to-px',
+  },
+};

--- a/packages/demo-todomvc/goji.config.js
+++ b/packages/demo-todomvc/goji.config.js
@@ -1,1 +1,5 @@
-module.exports = {};
+module.exports = {
+  css: {
+    unit: 'to-px',
+  },
+};

--- a/packages/goji.js.org/docs/advanced/config.md
+++ b/packages/goji.js.org/docs/advanced/config.md
@@ -210,3 +210,26 @@ This feature also works with
 - Default: `undefined`
 
 You can use this options to nohoist specific modules.
+
+### `css`
+
+Options to configure the processing of styles.
+
+### `css.unit`
+
+- Type: `undefined | 'keep' | 'to-px' | 'to-rpx'`
+
+- Default: `'to-rpx'`
+
+There is a built-in PostCSS plugin called
+[postcss-transform-unit](https://github.com/airbnb/goji-js/pull/231) that can be used to transform
+CSS units in all files. In some cases, you may want to convert the usage of `px` to `rpx` or vice
+versa. You can use this option.
+
+- `keep`: Do not transform any CSS unit.
+
+- `to-px`: Transform `rpx` to `px`. `2rpx` equals to `1px`.
+
+- `to-rpx`: Transform `px` to `rpx`. `1px` equals to `2rpx`.
+
+> The default will be changed to `keep` in the future.

--- a/packages/goji.js.org/i18n/zh/code.json
+++ b/packages/goji.js.org/i18n/zh/code.json
@@ -199,27 +199,27 @@
     "description": "The ARIA label for copy code blocks button"
   },
   "theme.CodeBlock.copy": {
-    "message": "Copy",
+    "message": "复制",
     "description": "The copy button label on code blocks"
   },
   "theme.navbar.mobileLanguageDropdown.label": {
-    "message": "Languages",
+    "message": "语言",
     "description": "The label for the mobile language switcher dropdown"
   },
   "theme.docs.sidebar.collapseButtonTitle": {
-    "message": "Collapse sidebar",
+    "message": "收起侧边栏",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.docs.sidebar.collapseButtonAriaLabel": {
-    "message": "Collapse sidebar",
+    "message": "收起侧边栏",
     "description": "The title attribute for collapse button of doc sidebar"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
-    "message": "← Back to main menu",
+    "message": "← 回到主菜单",
     "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
   },
   "theme.tags.tagsPageTitle": {
-    "message": "Tags",
+    "message": "标签",
     "description": "The title of the tag list page"
   },
   "home.button": {

--- a/packages/goji.js.org/i18n/zh/docusaurus-plugin-content-docs/current/advanced/config.md
+++ b/packages/goji.js.org/i18n/zh/docusaurus-plugin-content-docs/current/advanced/config.md
@@ -187,3 +187,23 @@ module.exports = {
 - 默认值: `undefined`
 
 您可以使用此选项来取消特定模块的提升。
+
+### `css`
+
+该选项可配置 CSS 的处理过程。
+
+### `css.unit`
+
+- 类型: `undefined | 'keep' | 'to-px' | 'to-rpx'`
+
+- 默认值: `'to-rpx'`
+
+GojiJS 有一个内置的 PostCSS 插件叫做 [postcss-transform-unit](https://github.com/airbnb/goji-js/pull/231)，它可用来转换所有文件中的 CSS 单位。 在某些情况下，您可能想要将 px`的用法转换为`rpx\` ，反之亦然。 您可以使用此选项。
+
+- `keep`: 不转换任何 CSS 单位。
+
+- `to-px`: 将 `rpx` 转换为 `px` 。 `2rpx`等于`1px`。
+
+- `to-rpx`: 将 `px` 转换为 `rpx` 。 `1px`等于`2rpx`。
+
+> 默认值将在将来更改为 "keep"

--- a/packages/goji.js.org/i18n/zh/docusaurus-plugin-content-docs/current/guide/lifecycle.md
+++ b/packages/goji.js.org/i18n/zh/docusaurus-plugin-content-docs/current/guide/lifecycle.md
@@ -45,7 +45,6 @@ const MyComp = ({ id }: { id: string }) => {
   }, [id]);
 
   return data ? data : 'loading';
-}; data : 'loading';
 };
 ```
 

--- a/packages/webpack-plugin/src/plugins/__tests__/hoist.test.ts
+++ b/packages/webpack-plugin/src/plugins/__tests__/hoist.test.ts
@@ -32,6 +32,7 @@ describe('hoist', () => {
         enable: true,
         maxPackages: Infinity,
       },
+      cssUnit: 'to-px',
     });
     const compiler = webpack(webpackConfig);
     await new Promise<webpack.Stats | undefined>((resolve, reject) => {


### PR DESCRIPTION
This PR introduced a new option `css.unit` in `goji.config.js` to enable CSS unit transforming.

### `css.unit`

- Type: `undefined | 'keep' | 'to-px' | 'to-rpx'`

- Default: `'to-rpx'`

There is a built-in PostCSS plugin called `postcss-transform-unit` that can be used to transform CSS
units in all files. In some cases, you may want to convert the usage of `px` to `rpx` or vice versa.
You can use this option.

- `keep`: Do not transform any CSS unit.

- `to-px`: Transform `rpx` to `px`. `2rpx` equals to `1px`.

- `to-rpx`: Transform `px` to `rpx`. `1px` equals to `2rpx`.

> The default will be changed to `keep` in the future.