### PR TITLE
Fix <input> cursor issue

### DIFF
--- a/packages/webpack-plugin/src/templates/commons/wrapped.ts
+++ b/packages/webpack-plugin/src/templates/commons/wrapped.ts
@@ -24,7 +24,7 @@ export const updateInternalValueHandler = (eventName: string, propName: string) 
 
 export const WRAPPED_CONFIGS: Record<string, WrappedConfig> = {
   input: {
-    memorizedProps: ['value', 'focus'],
+    memorizedProps: ['value', 'focus', 'cursor'],
     customizedEventHandler: {
       input: updateInternalValueHandler('input', 'value'),
     },

--- a/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/wrapped.js.test.tsx.snap
+++ b/packages/webpack-plugin/src/templates/components/__tests__/__snapshots__/wrapped.js.test.tsx.snap
@@ -47,6 +47,9 @@ exports[`wrapped.js snapshot works: input 1`] = `
     internalFocus: {
       value: false
     },
+    internalCursor: {
+      value: 0
+    },
   },
   properties: {
     meta: {
@@ -61,6 +64,11 @@ exports[`wrapped.js snapshot works: input 1`] = `
         if (this.properties.meta.props.focus !== this.data.internalFocus.value) {
           update.internalFocus = {
             value: this.properties.meta.props.focus
+          };
+        }
+        if (this.properties.meta.props.cursor !== this.data.internalCursor.value) {
+          update.internalCursor = {
+            value: this.properties.meta.props.cursor
           };
         }
         if (Object.keys(update)) {
@@ -78,6 +86,9 @@ exports[`wrapped.js snapshot works: input 1`] = `
         },
         internalFocus: {
           value: this.properties.meta.props.focus
+        },
+        internalCursor: {
+          value: this.properties.meta.props.cursor
         },
       });
     },


### PR DESCRIPTION
We have to memorize the `cursor` attr of `<input>` to fix the issue.

Before:
![ScreenRecording_03-06-2025 18-04-04_1](https://github.com/user-attachments/assets/4b743ace-a539-4c69-bc23-a23bb91e4190)

After:
![ScreenRecording_03-06-2025 18-01-46_1](https://github.com/user-attachments/assets/fdba6cc5-69e7-4521-adcb-d9c2739b8996)
