### PR TITLE
fix: `merge()` treating sibling prop keys as parent/child paths

### DIFF
--- a/packages/core/src/utils/__tests__/merge.test.ts
+++ b/packages/core/src/utils/__tests__/merge.test.ts
@@ -80,4 +80,31 @@ describe('mergeDiff', () => {
       children: [],
     });
   });
+
+  it('does not confuse sibling keys sharing a string prefix', () => {
+    const existing = {
+      'meta.children[0].props.titleColor': 'red',
+    };
+    const diff = {
+      'meta.children[0].props.title': 'hello',
+    };
+
+    expect(merge(existing, diff)).toEqual({
+      'meta.children[0].props.titleColor': 'red',
+      'meta.children[0].props.title': 'hello',
+    });
+  });
+
+  it('still treats a real path boundary as a parent/child relationship', () => {
+    const existing = {
+      'children[0].text': 'bula',
+    };
+    const diff = {
+      'children[0]': { text: '233' },
+    };
+
+    expect(merge(existing, diff)).toEqual({
+      'children[0]': { text: '233' },
+    });
+  });
 });

--- a/packages/core/src/utils/merge.ts
+++ b/packages/core/src/utils/merge.ts
@@ -1,5 +1,20 @@
 import set from 'lodash/set';
 
+// `prefix` is considered an ancestor of (or equal to) `target` only if the match
+// ends on a real path boundary (`.` or `[`), otherwise sibling keys that merely
+// share a string prefix (e.g. `props.title` vs `props.titleColor`) would be
+// mistaken for a parent/child relationship.
+const isPathPrefix = (prefix: string, target: string) => {
+  if (prefix === target) {
+    return true;
+  }
+  if (!target.startsWith(prefix)) {
+    return false;
+  }
+  const boundaryChar = target[prefix.length];
+  return boundaryChar === '.' || boundaryChar === '[';
+};
+
 export const merge = (merged: Record<string, any>, diff: Record<string, any>) => {
   let before: Record<string, any> | null = null;
   if (process.env.NODE_ENV === 'development') {
@@ -11,11 +26,11 @@ export const merge = (merged: Record<string, any>, diff: Record<string, any>) =>
   for (const newKey of diffKeys) {
     let matched = false;
     for (const oldKey of existingKeys) {
-      if (oldKey.startsWith(newKey)) {
+      if (isPathPrefix(newKey, oldKey)) {
         delete merged[oldKey];
         merged[newKey] = diff[newKey];
         matched = true;
-      } else if (newKey.startsWith(oldKey)) {
+      } else if (isPathPrefix(oldKey, newKey)) {
         let val = merged[oldKey] as Record<string, any>;
         let subpath = newKey.substring(oldKey.length);
         if (subpath.startsWith('.')) {


### PR DESCRIPTION
## Summary

- `merge()` decided whether one diff path was an ancestor of another using a plain `String#startsWith` check, with no path-boundary validation. As a result, sibling keys that merely share a string prefix (e.g. `props.title` vs `props.titleColor`) were mistaken for a parent/child relationship, and one of them was silently dropped during `gojiBlockingMode` diff merges.
- Added `isPathPrefix()`, which only treats `prefix` as an ancestor of `target` when the match ends on a real path boundary (`.`, `[`, or end of string), and used it in place of the raw `startsWith` comparisons.

## Test plan

**before**
- [x] All existing tests in `packages/core` pass

**after**
- [x] `merge.test.ts`: added a regression test for sibling keys sharing a string prefix
- [x] `merge.test.ts`: added a test confirming real path-boundary matches (`children[0]` / `children[0].text`) still work as 