### PR TITLE
Fix merge sibling key prefix collision

### DIFF
--- a/packages/core/src/utils/__tests__/merge.test.ts
+++ b/packages/core/src/utils/__tests__/merge.test.ts
@@ -80,4 +80,18 @@ describe('mergeDiff', () => {
       children: [],
     });
   });
+
+  it('does not confuse sibling keys sharing a string prefix', () => {
+    const existing = {
+      'meta.children[0].props.titleColor': 'red',
+    };
+    const diff = {
+      'meta.children[0].props.title': 'hello',
+    };
+
+    expect(merge(existing, diff)).toEqual({
+      'meta.children[0].props.titleColor': 'red',
+      'meta.children[0].props.title': 'hello',
+    });
+  });
 });

--- a/packages/core/src/utils/merge.ts
+++ b/packages/core/src/utils/merge.ts
@@ -1,5 +1,8 @@
 import set from 'lodash/set';
 
+const isPathPrefix = (prefix: string, target: string) =>
+  target === prefix || target.startsWith(`${prefix}.`) || target.startsWith(`${prefix}[`);
+
 export const merge = (merged: Record<string, any>, diff: Record<string, any>) => {
   let before: Record<string, any> | null = null;
   if (process.env.NODE_ENV === 'development') {
@@ -11,11 +14,11 @@ export const merge = (merged: Record<string, any>, diff: Record<string, any>) =>
   for (const newKey of diffKeys) {
     let matched = false;
     for (const oldKey of existingKeys) {
-      if (oldKey.startsWith(newKey)) {
+      if (isPathPrefix(newKey, oldKey)) {
         delete merged[oldKey];
         merged[newKey] = diff[newKey];
         matched = true;
-      } else if (newKey.startsWith(oldKey)) {
+      } else if (isPathPrefix(oldKey, newKey)) {
         let val = merged[oldKey] as Record<string, any>;
         let subpath = newKey.substring(oldKey.length);
         if (subpath.startsWith('.')) {


### PR DESCRIPTION
This PR fixed a bug that `merge()` used `String#startsWith` to decide path ancestry, so sibling key `props.title` matched `props.titleColor` and silently dropped a value during blocking-mode diff merges.

Close https://github.com/airbnb/goji-js/pull/315