### PR TITLE
chore: Remove duplicate `toutiao` entry from GojiTarget lists

### DIFF
--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -8,7 +8,7 @@ export interface CliConfig {
   progress?: boolean;
 }
 
-const GOJI_TARGETS: Array<GojiTarget> = ['wechat', 'baidu', 'alipay', 'toutiao', 'qq', 'toutiao'];
+const GOJI_TARGETS: Array<GojiTarget> = ['wechat', 'baidu', 'alipay', 'toutiao', 'qq'];
 
 export const parseArgv = (arg: Array<string>) => new Promise<CliConfig>((resolve, reject) => {
     const yargsConfig = yargs

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,7 +2,7 @@ export const GOJI_VIRTUAL_ROOT = 'GOJI_VIRTUAL_ROOT';
 export const TYPE_TEXT = 'GOJI_TYPE_TEXT';
 export const TYPE_SUBTREE = 'GOJI_TYPE_SUBTREE';
 
-export type GojiTarget = 'wechat' | 'baidu' | 'alipay' | 'toutiao' | 'qq' | 'toutiao';
+export type GojiTarget = 'wechat' | 'baidu' | 'alipay' | 'toutiao' | 'qq';
 
 export interface SimplifyComponent {
   name: string;

--- a/packages/create-goji-app/src/index.ts
+++ b/packages/create-goji-app/src/index.ts
@@ -14,7 +14,7 @@ const shouldUseYarn = () => {
   }
 };
 
-const TARGETS = ['wechat', 'baidu', 'alipay', 'toutiao', 'qq', 'toutiao'];
+const TARGETS = ['wechat', 'baidu', 'alipay', 'toutiao', 'qq'];
 
 const main = async () => {
   const argv = process.argv.slice(2);


### PR DESCRIPTION
## Summary

### Motivation
- `GojiTarget` (`packages/core/src/constants.ts`) and its hand-copied arrays in `packages/cli/src/argv.ts` (`GOJI_TARGETS`) and `packages/create-goji-app/src/index.ts` (`TARGETS`) all listed `'toutiao'` twice: `'wechat' | 'baidu' | 'alipay' | 'toutiao' | 'qq' | 'toutiao'`.
- This showed up directly in user-facing output: the CLI's `--target` choices/help text and the `create-goji-app` scaffolding prompt both displayed `toutiao` redundantly.

### What I have done
- Removed the duplicate in all three places, leaving the intended 5 targets: `wechat` / `baidu` / `alipay` / `toutiao` / `qq`.

### Test plans
- [x] `packages/cli/src/__tests__/argv.test.ts` passes unchanged
- [x] Confirmed `toutiao` is still used consistently as a single valid target elsewhere in the codebase (webpack-plugin, render tests, etc.)
