### PR TITLE
fix: `getChunkName()` infinite recursion when chunk has no name

### DIFF
--- a/packages/webpack-plugin/src/utils/__tests__/chunkName.test.ts
+++ b/packages/webpack-plugin/src/utils/__tests__/chunkName.test.ts
@@ -1,0 +1,14 @@
+import webpack from 'webpack';
+import { getChunkName } from '../chunkName';
+
+describe('getChunkName', () => {
+  it('returns the chunk name when present', () => {
+    expect(getChunkName({ name: 'main' } as webpack.Chunk)).toBe('main');
+  });
+
+  it('throws a descriptive error instead of recursing when the chunk has no name', () => {
+    expect(() => getChunkName({ name: undefined } as unknown as webpack.Chunk)).toThrow(
+      'getChunkName(chunk) expected string but got undefined',
+    );
+  });
+});

--- a/packages/webpack-plugin/src/utils/chunkName.ts
+++ b/packages/webpack-plugin/src/utils/chunkName.ts
@@ -2,7 +2,7 @@ import webpack from 'webpack';
 
 export const getChunkName = (chunk: webpack.Chunk) => {
   if (!chunk.name) {
-    throw new Error(`getChunkName(chunk) expected string but got ${typeof getChunkName(chunk)}`);
+    throw new Error(`getChunkName(chunk) expected string but got ${typeof chunk.name}`);
   }
   return chunk.name;
 };


### PR DESCRIPTION
## Summary

### Motivation
- `getChunkName(chunk)` builds its error message by calling `typeof getChunkName(chunk)` when `chunk.name` property type is  false. 
That nested call re-enters the same `if (!chunk.name)` branch, which calls `getChunkName(chunk)` again, and so on — an infinite recursion that overflows the call stack instead of throwing the intended, readable error.
- `getChunkName` is used widely across the webpack plugin (`nohoist.ts`, `entry.ts`, `split.ts`, `runtime.ts`, `singleton.ts`), so any nameless chunk (e.g. an anonymous intermediate chunk produced during optimization) crashes the build with a confusing `RangeError: Maximum call stack size exceeded` instead of a clear message.

### What I have done
- Replaced the recursive `typeof getChunkName(chunk)` with `typeof chunk.name`, since the value is already in scope and doesn't need to be recomputed by calling the function again.
- Added regression tests covering the happy path (returns the name) and the error path (throws a descriptive error instead of recursing) when the chunk has no name.

### Test Plans
- [x] `packages/webpack-plugin/src/utils/__tests__/chunkName.test.ts` (new): both cases pass
- [x] Confirmed the failing case previously caused unbounded recursion by testing against the pre-fix code
